### PR TITLE
Fix: scope to pass config

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -52,7 +52,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 			\Magento\Store\Model\ScopeInterface::SCOPE_STORE
 		);
 		// special search configs
-
 		$cfg['searchbar_type'] = $this->_escaper->escapeHtml(
 			$this->scopeConfig->getValue(
 				'cc_uk/gfx_options/searchbar_type',
@@ -61,7 +60,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 		);
 
 		// errors
-
 		$cfg['error_msg'] = [];
 		$cfg['error_msg']["0001"] = $this->_escaper->escapeHtml(
 			$this->scopeConfig->getValue(

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	 "magento/magento-composer-installer": "*"
     },
     "type": "magento2-module",
-    "version": "0.1.9-beta",
+    "version": "0.2.0-beta",
     "extra": {
         "map": [
             [

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -54,6 +54,7 @@
 				<field id="hide_fields" translate="label" type="select" sortOrder="7" showInDefault="1">
 					<label>Hide Address Fields of New Address Entry</label>
 					<source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+					<comment>Only for the store front</comment>
 				</field>
 				<field id="searchbar_clean_postsearch" translate="label" type="select" sortOrder="32" showInDefault="1">
 					<label>Clean Input after Search</label>

--- a/view/adminhtml/web/form_integrations/cc_admin_customer.js
+++ b/view/adminhtml/web/form_integrations/cc_admin_customer.js
@@ -1,5 +1,3 @@
-
-var cc_attached = [];
 function activate_cc_m2(){
 	if(crafty_cfg.enabled){
 		var cfg = {
@@ -36,42 +34,44 @@ function activate_cc_m2(){
 			txt: crafty_cfg.txt,
 			error_msg: crafty_cfg.error_msg
 		};
-		var address_dom = {
-			company:	jQuery("[name$='[company]']"),
-			address_1:	jQuery("[name$='[street][0]']"),
-			address_2:	jQuery("[name$='[street][1]']"),
-			postcode:	jQuery("[name$='[postcode]']"),
-			town:		jQuery("[name$='[city]']"),
-			county:		jQuery("[name$='[region]']"),
-			county_list:jQuery("select[name$='[region_id]']"),
-			country:	jQuery("select[name$='[country_id]']")
+		var dom = {
+			company:	'[name$="[company]"]',
+			address_1:	'[name$="[street][0]"]',
+			address_2:	'[name$="[street][1]"]',
+			postcode:	'[name$="[postcode]"]',
+			town:		'[name$="[city]"]',
+			county:		'[name$="[region]"]',
+			county_list:'select[name$="[region_id]"]',
+			country:	'select[name$="[country_id]"]'
 		};
 		// special for admin panel: search each potential element
-		address_dom.postcode.each(function(index){
-			// different tagging method; tag object as active
-			if(jQuery(this).data('cc') != 'active'){
-				cfg.dom = {
-					company:	jQuery(jQuery("[name$='[company]']")[index]),
-					address_1:	jQuery(jQuery("[name$='[street][0]']")[index]),
-					address_2:	jQuery(jQuery("[name$='[street][1]']")[index]),
-					postcode:	jQuery(jQuery("[name$='[postcode]']")[index]),
-					town:		jQuery(jQuery("[name$='[city]']")[index]),
-					county:		jQuery(jQuery("[name$='[region]']")[index]),
-					county_list:jQuery(jQuery("select[name$='[region_id]']")[index]),
-					country:	jQuery(jQuery("select[name$='[country_id]']")[index])
+		var postcode_elements = jQuery(dom.postcode);
+		postcode_elements.each(function(index){
+			if(postcode_elements.eq(index).data('cc') != '1'){
+				var active_cfg = {};
+				jQuery.extend(active_cfg, cfg);
+				active_cfg.id = "m2_"+cc_index;
+				var form = postcode_elements.eq(index).closest('fieldset');
+				cc_index++;
+				active_cfg.dom = {
+					company:		form.find(dom.company),
+					address_1:		form.find(dom.address_1),
+					address_2:		form.find(dom.address_2),
+					postcode:		postcode_elements.eq(index),
+					town:			form.find(dom.town),
+					county:			form.find(dom.county),
+					county_list:	form.find(dom.county_list),
+					country:		form.find(dom.country)
 				};
-				jQuery(this).data('cc','active');
-				console.log(cfg.dom);
-
-				cfg.id = jQuery(this).attr('name');
-
-				cc_attached.push(new cc_ui_handler(cfg));
-				cc_attached[cc_attached.length - 1].activate();
+				active_cfg.dom.postcode.data('cc','1');
+				var cc_generic = new cc_ui_handler(active_cfg);
+				cc_generic.activate();
 			}
 		});
 	}
 }
 
+var cc_index = 0;
 requirejs(['jquery'], function( $ ) {
 	jQuery( document ).ready(function() {
 		if(crafty_cfg.enabled){

--- a/view/adminhtml/web/form_integrations/cc_admin_order.js
+++ b/view/adminhtml/web/form_integrations/cc_admin_order.js
@@ -1,5 +1,3 @@
-
-var cc_activate_flags = [];
 function activate_cc_m2(){
 	if(crafty_cfg.enabled){
 		var cfg = {
@@ -31,26 +29,43 @@ function activate_cc_m2(){
 			txt: crafty_cfg.txt,
 			error_msg: crafty_cfg.error_msg
 		};
-		var address_dom = {
-			company:	jQuery("[name='company']"),
-			address_1:	jQuery("[name='street[0]']"),
-			address_2:	jQuery("[name='street[1]']"),
-			postcode:	jQuery("[name='postcode']"),
-			town:		jQuery("[name='city']"),
-			county:		jQuery("[name='region']"),
-			county_list:jQuery("[name='region_id']"),
-			country:	jQuery("[name='country_id']")
+		var dom = {
+			company:	'[name="company"]',
+			address_1:	'[name="street[0]"]',
+			address_2:	'[name="street[1]"]',
+			postcode:	'[name="postcode"]',
+			town:		'[name="city"]',
+			county:		'[name="region"]',
+			county_list:'[name="region_id"]',
+			country:	'[name="country_id"]'
 		};
-		cfg.dom = address_dom;
-		cfg.id = "m2_address";
-		if(cc_activate_flags.indexOf(cfg.id) == -1 && cfg.dom.postcode.length == 1){
-			cc_activate_flags.push(cfg.id);
-			var cc_billing = new cc_ui_handler(cfg);
-			cc_billing.activate();
-		}
+		var postcode_elements = jQuery(dom.postcode);
+		postcode_elements.each(function(index){
+			if(postcode_elements.eq(index).data('cc') != '1'){
+				var active_cfg = {};
+				jQuery.extend(active_cfg, cfg);
+				active_cfg.id = "m2_"+cc_index;
+				var form = postcode_elements.eq(index).closest('fieldset');
+				cc_index++;
+				active_cfg.dom = {
+					company:		form.find(dom.company),
+					address_1:		form.find(dom.address_1),
+					address_2:		form.find(dom.address_2),
+					postcode:		postcode_elements.eq(index),
+					town:			form.find(dom.town),
+					county:			form.find(dom.county),
+					county_list:	form.find(dom.county_list),
+					country:		form.find(dom.country)
+				};
+				active_cfg.dom.postcode.data('cc','1');
+				var cc_generic = new cc_ui_handler(active_cfg);
+				cc_generic.activate();
+			}
+		});
 	}
 }
 
+var cc_index = 0;
 requirejs(['jquery'], function( $ ) {
 	jQuery( document ).ready(function() {
 		if(crafty_cfg.enabled){

--- a/view/adminhtml/web/form_integrations/cc_admin_order_create_customer.js
+++ b/view/adminhtml/web/form_integrations/cc_admin_order_create_customer.js
@@ -31,26 +31,44 @@ function activate_cc_m2(){
 			txt: crafty_cfg.txt,
 			error_msg: crafty_cfg.error_msg
 		};
-		var address_dom = {
-			company:	jQuery("#order-billing_address_company"),
-			address_1:	jQuery("#order-billing_address_street0"),
-			address_2:	jQuery("#order-billing_address_street1"),
-			postcode:	jQuery("#order-billing_address_postcode"),
-			town:		jQuery("#order-billing_address_city"),
-			county:		jQuery("#order-billing_address_region"),
-			county_list:jQuery("#order-billing_address_region_id"),
-			country:	jQuery("#order-billing_address_country_id")
+		var dom = {
+			company:	'[name$="_address][company]"]',
+			address_1:	'[name$="_address][street][0]"]',
+			address_2:	'[name$="_address][street][1]"]',
+			postcode:	'[name$="_address][postcode]"]',
+			town:		'[name$="_address][city]"]',
+			county:		'[name$="_address][region]"]',
+			county_list:'[name$="_address][region_id]"]',
+			country:	'select[name$="_address][country_id]"]'
 		};
-		cfg.dom = address_dom;
-		cfg.id = "m2_address";
-		if(cc_activate_flags.indexOf(cfg.id) == -1 && cfg.dom.postcode.length == 1){
-			cc_activate_flags.push(cfg.id);
-			var cc_billing = new cc_ui_handler(cfg);
-			cc_billing.activate();
-		}
+		var postcode_elements = jQuery(dom.postcode);
+		postcode_elements.each(function(index){
+			if(postcode_elements.eq(index).data('cc') != '1'){
+				var active_cfg = {};
+				jQuery.extend(active_cfg, cfg);
+				active_cfg.id = "m2_"+cc_index;
+				var form = postcode_elements.eq(index).closest('fieldset');
+				console.log(form);
+				cc_index++;
+				active_cfg.dom = {
+					company:		form.find(dom.company),
+					address_1:		form.find(dom.address_1),
+					address_2:		form.find(dom.address_2),
+					postcode:		postcode_elements.eq(index),
+					town:			form.find(dom.town),
+					county:			form.find(dom.county),
+					county_list:	form.find(dom.county_list),
+					country:		form.find(dom.country)
+				};
+				active_cfg.dom.postcode.data('cc','1');
+				var cc_generic = new cc_ui_handler(active_cfg);
+				cc_generic.activate();
+			}
+		});
 	}
 }
 
+var cc_index = 0;
 requirejs(['jquery'], function( $ ) {
 	jQuery( document ).ready(function() {
 		if(crafty_cfg.enabled){

--- a/view/base/web/cc_middleman.js
+++ b/view/base/web/cc_middleman.js
@@ -4,7 +4,7 @@
  */
 
 function cc_ui_handler(cfg){
-	console.log(cfg);
+	//console.log(cfg);
 	this.cfg = cfg;
 
 	var lines = 0;
@@ -76,14 +76,14 @@ cc_ui_handler.prototype.country_change = function(country){
 		this.search_object.parents(this.cfg.sort_fields.parent).last().hide();
 	}
 	if(active_countries.indexOf(country) != -1){
-		jQuery('.search-bar .action').show();
+		this.search_object.find('.search-bar .action').show();
 	} else {
-		jQuery('.search-bar .action').hide();
+		this.search_object.find('.search-bar .action').hide();
 	}
 	if(this.cfg.hide_fields && (active_countries.indexOf(country) != -1) && (this.cfg.dom.postcode.val() === "")){
-		jQuery('.crafty_address_field').hide();
+		this.search_object.closest(this.cfg.sort_fields.parent).parent().find('.crafty_address_field').hide();
 	} else {
-		jQuery('.crafty_address_field').show();
+		this.search_object.closest(this.cfg.sort_fields.parent).parent().find('.crafty_address_field').show();
 	}
 };
 
@@ -225,8 +225,12 @@ cc_ui_handler.prototype.lookup = function(postcode){
 		});
 	}
 };
-cc_ui_handler.prototype.prompt_error = function(errorcode){
-	this.search_object.find('.mage-error .search-subtext').html(this.cfg.error_msg[errorcode]);
+cc_ui_handler.prototype.prompt_error = function(error_code){
+	if(!this.cfg.error_msg.hasOwnProperty(error_code)){
+		// simplyfy complex error messages
+		error_code = "0004";
+	}
+	this.search_object.find('.mage-error .search-subtext').html(this.cfg.error_msg[error_code]);
 	this.search_object.find('.mage-error').show();
 };
 cc_ui_handler.prototype.select = function(postcode, id){

--- a/view/base/web/cc_rapid_core.js
+++ b/view/base/web/cc_rapid_core.js
@@ -55,13 +55,13 @@ cc_rapid.prototype.search = function(input){
 }
 // gets data from storage
 cc_rapid.prototype.get_store = function(postcode){
-	console.warn('retrieving data from store');
+	//console.warn('retrieving data from store');
 	return this.dataStore[postcode];
 }
 // adds data to storage
 cc_rapid.prototype.store = function(postcode, object){
 	this.dataStore[postcode] = object;
-	console.warn('data saved');
+	//console.warn('data saved');
 	return true;
 }
 // checks if postcode related data is already stored
@@ -88,7 +88,7 @@ cc_rapid.prototype.fetch_data = function(postcode){
 			if (this.status >= 200 && this.status < 400){
 				// Success!
 				data = JSON.parse(this.responseText);
-				console.log(data);
+				//console.log(data);
 			} else {
 				data = { error_code: "0004" };
 			}
@@ -124,8 +124,6 @@ cc_rapid.prototype.format_data = function(data){
 				data.delivery_points[i].organisation_name = this.leading_caps(data.delivery_points[i].organisation_name);
 			}
 		}
-	} else {
-		console.log('wat');
 	}
 	return data;
 }

--- a/view/frontend/web/form_integrations/cc_default_checkout.js
+++ b/view/frontend/web/form_integrations/cc_default_checkout.js
@@ -18,18 +18,6 @@ function activate_cc_m2(){
 				parent: 'div.field:not(.additional)'
 			},
 			search_type: crafty_cfg.searchbar_type,
-			/*
-			searchbar_gfx: {
-				bg:		{
-					color: crafty_cfg.search_bg_color,
-					type: crafty_cfg.search_bg
-				},
-				icon:	{
-					color: crafty_cfg.search_icon_color,
-					type: crafty_cfg.search_icon
-				}
-			},
-			*/
 			hide_fields: crafty_cfg.hide_fields,
 			auto_search: crafty_cfg.auto_search,
 			clean_postsearch: crafty_cfg.clean_postsearch,
@@ -41,43 +29,36 @@ function activate_cc_m2(){
 			txt: crafty_cfg.txt,
 			error_msg: crafty_cfg.error_msg
 		};
-		/*
-		var billing_dom = {
-			company:	jQuery("[name='billingAddresscheckmo[company]']"),
-			address_1:	jQuery("[name='billingAddresscheckmo[street][0]']"),
-			address_2:	jQuery("[name='billingAddresscheckmo[street][1]']"),
-			postcode:	jQuery("[name='billingAddresscheckmo[postcode]']"),
-			town:		jQuery("[name='billingAddresscheckmo[city]']"),
-			county:		jQuery("[name='billingAddresscheckmo[region]']"),
-			county_list:jQuery("[name='billingAddresscheckmo[region_id]']"),
-			country:	jQuery("[name='billingAddresscheckmo[country_id]']")
-		};*/
-		dom = {
-			company:	jQuery("[name='company']"),
-			address_1:	jQuery("[name='street[0]']"),
-			address_2:	jQuery("[name='street[1]']"),
-			postcode:	jQuery("[name='postcode']"),
-			town:		jQuery("[name='city']"),
-			county:		jQuery("[name='region']"),
-			county_list:jQuery("[name='region_id']"),
-			country:	jQuery("[name='country_id']")
+		var dom = {
+			company:	'[name="company"]',
+			address_1:	'[name="street[0]"]',
+			address_2:	'[name="street[1]"]',
+			postcode:	'[name="postcode"]',
+			town:		'[name="city"]',
+			county:		'[name="region"]',
+			county_list:'[name="region_id"]',
+			country:	'[name="country_id"]'
 		};
-		dom.postcode.each(function(index){
-			if(dom.postcode.eq(index).data('cc') != '1'){
-				cfg.id = "m2_"+cc_index;
+		var postcode_elements = jQuery(dom.postcode);
+		postcode_elements.each(function(index){
+			if(postcode_elements.eq(index).data('cc') != '1'){
+				var active_cfg = {};
+				jQuery.extend(active_cfg, cfg);
+				active_cfg.id = "m2_"+cc_index;
+				var form = postcode_elements.eq(index).closest('form');
 				cc_index++;
-				cfg.dom = {
-					company:		dom.company.eq(index),
-					address_1:		dom.address_1.eq(index),
-					address_2:		dom.address_2.eq(index),
-					postcode:		dom.postcode.eq(index),
-					town:			dom.town.eq(index),
-					county:			dom.county.eq(index),
-					county_list:	dom.county_list.eq(index),
-					country:		dom.country.eq(index)
+				active_cfg.dom = {
+					company:		form.find(dom.company),
+					address_1:		form.find(dom.address_1),
+					address_2:		form.find(dom.address_2),
+					postcode:		postcode_elements.eq(index),
+					town:			form.find(dom.town),
+					county:			form.find(dom.county),
+					county_list:	form.find(dom.county_list),
+					country:		form.find(dom.country)
 				};
-				cfg.dom.postcode.data('cc','1');
-				var cc_generic = new cc_ui_handler(cfg);
+				active_cfg.dom.postcode.data('cc','1');
+				var cc_generic = new cc_ui_handler(active_cfg);
 				cc_generic.activate();
 			}
 		});


### PR DESCRIPTION
- Moved the config to the scope where middleman.js is called.
  (previously pages with multiple address forms on one page were broken,
  due to cfg overwrite)
- Restricted selectors for hiding / revealing input elements / postcode
  lookup button. (button got hidden on all forms if on one form the user
  switched away from UK)
