### PR TITLE
Fade in and focus on postcode lookup

### DIFF
--- a/view/base/web/cc_ukpcl_lib.js
+++ b/view/base/web/cc_ukpcl_lib.js
@@ -388,7 +388,7 @@ cc_ui_handler.prototype.lookup = function(postcode) {
 			html += '<option data-id="' + i + '">' + lines[i] + '</option>';
 		}
 		search_list.find('select').html(html);
-		search_list.show();
+		search_list.fadeIn().find('select').focus();
 	};
 	var select_builder = this.cfg.ui.select_builder || default_select_builder;
 	select_builder(results, search_list);


### PR DESCRIPTION
## Bring user focus to results in postcode lookup
I noticed that during checkout you would sometimes miss the select appearing when using postcode lookup (especially on mobile devices). To make checkout process as easy as possible I have made the search list fade in and then focus on the select so that the address selection is brought to the attention of the user.