### PR TITLE
Version 2.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "fetchify/module-fetchify",
     "description": "Adds data capture and validation products by Fetchify (previously Crafty Clicks) to Magento 2.",
     "type": "magento2-module",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "authors": [
         {
             "name": "Gabor Peter Suranyi",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -13,7 +13,7 @@
 				<field id="enable_extension" translate="label" type="select" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
 					<label>Enable Extension</label>
 					<source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-					<comment>Fetchify Version: 2.7.0</comment>
+					<comment>Fetchify Version: 2.8.0</comment>
 				</field>
 				<field id="accesstoken" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
 					<label>Access Token</label>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Fetchify_Fetchify" setup_version="2.7.0">
+	<module name="Fetchify_Fetchify" setup_version="2.8.0">
 		<sequence>
 			<module name="Magento_Persistent"/>
 		</sequence>

--- a/view/adminhtml/web/enhance.css
+++ b/view/adminhtml/web/enhance.css
@@ -1,4 +1,4 @@
-.color-cube {
+.colour-cube {
 	height: 20px;
 	width: 20px;
 	margin: 2px;
@@ -6,11 +6,11 @@
 	border: 2px solid white;
 }
 
-.color-cube:hover {
+.colour-cube:hover {
 	border-color: #63a2f1;
 }
 
-.color-cube.active {
+.colour-cube.active {
 	border-color: black;
 }
 

--- a/view/adminhtml/web/enhance.js
+++ b/view/adminhtml/web/enhance.js
@@ -1,12 +1,14 @@
-require(['jquery', 'jquery/ui', 'jquery/validate', 'mage/translate'], function(jQuery) {
-	jQuery(document).ready(function() {
-		if (jQuery('#fetchify_global_gfx_options_accent').length) {
-			jQuery('#fetchify_global_gfx_options_accent').hide();
+require(['jquery', 'jquery/ui', 'jquery/validate'], function(jQuery) {
+	function enhance_config() {
+		if (document.getElementById('fetchify_global_gfx_options_accent')) {
+			document.getElementById('fetchify_global_gfx_options_accent').style.display = 'none';
 
-			var colorpicker = '<div class="color-set"></div>';
-			jQuery('#fetchify_global_gfx_options_accent').after(colorpicker);
+			var colourpicker = document.createElement('div');
+			colourpicker.classList.add('colour-set');
 
-			var colors = {
+			document.getElementById('fetchify_global_gfx_options_accent').after(colourpicker);
+
+			var colours = {
 				default:	'#63a2f1',
 				red:		'#F44336',
 				pink:		'#E91E63',
@@ -29,23 +31,28 @@ require(['jquery', 'jquery/ui', 'jquery/validate', 'mage/translate'], function(j
 				blueGrey:	'#607d8b'
 			};
 
-			var keys = Object.keys(colors);
+			var keys = Object.keys(colours);
 
 			for (var i = 0; i < keys.length; i++) {
-				jQuery('.color-set').append('<div class="color-cube" data-value="' + keys[i] + '" style="background-color: ' + colors[keys[i]] + '"></div>');
+				var colour_cube = document.createElement('div');
+				colour_cube.classList.add('colour-cube');
+				colour_cube.dataset.value = keys[i];
+				colour_cube.style.backgroundColor = colours[keys[i]];
+
+				document.querySelector('.colour-set').append(colour_cube);
 			}
 
-			var initial_cube = jQuery('#fetchify_global_gfx_options_accent').val();
+			var initial_cube = document.getElementById('fetchify_global_gfx_options_accent').value;
 
-			jQuery('.color-set .color-cube').each(function(index, item) {
-				if (jQuery(item).data('value') == initial_cube) {
-					jQuery(item).addClass('active');
+			document.querySelectorAll('.colour-set .colour-cube').forEach(function(item) {
+				if (item.dataset.value == initial_cube) {
+					item.classList.add('active');
 				}
 
-				jQuery(item).on('click', function(event) {
-					jQuery('#fetchify_global_gfx_options_accent').val(jQuery(this).data('value'));
-					jQuery('.color-set .color-cube').each(function(index, cube) { jQuery(cube).removeClass('active'); });
-					jQuery(this).addClass('active');
+				item.addEventListener('click', (e) => {
+					document.getElementById('fetchify_global_gfx_options_accent').value = e.target.dataset.value;
+					document.querySelectorAll('.colour-set .colour-cube').forEach(function(cube) { cube.classList.remove('active'); });
+					e.target.classList.add('active');
 				});
 			});
 		}
@@ -53,7 +60,7 @@ require(['jquery', 'jquery/ui', 'jquery/validate', 'mage/translate'], function(j
 		jQuery.validator.addMethod('token-format', function(value, element) {
 			// attempt to correct typos
 			value = value.toLowerCase().replace(/-{2,}/g, '-').replace(/^-|-$|[^a-f0-9-]/g, '');
-			jQuery('#fetchify_main_main_options_accesstoken').val(value);
+			document.getElementById('fetchify_main_main_options_accesstoken').value = value;
 
 			// validate token format
 			var patt = /(?!xxxxx)^[a-f0-9?]{5}?(-[a-f0-9]{5}){3}?$/;
@@ -66,12 +73,18 @@ require(['jquery', 'jquery/ui', 'jquery/validate', 'mage/translate'], function(j
 
 		jQuery.validator.addMethod('exclusion-areas', function(value, element) {
 			value = value.toLowerCase().replace(/ /g, '');
-			jQuery('#fetchify_global_exclusions_areas').val(value);
+			document.getElementById('fetchify_global_exclusions_areas').value = value;
 
 			var patt = /^[a-z_,]*$/;
 			if (patt.test(value)) {
 				return this.optional(element) || patt.test(value);
 			}
 		}, 'Please do not include numbers or special characters (except for underscores and commas).');
-	});
+	}
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', enhance_config);
+	} else {
+		enhance_config();
+	}
 });

--- a/view/adminhtml/web/form_integrations/cc_admin_order.js
+++ b/view/adminhtml/web/form_integrations/cc_admin_order.js
@@ -1,24 +1,41 @@
+// Address AutoComplete
 function activate_cc_m2() {
-	jQuery('[name="postcode"]').each(function(index, elem) {
-		if (jQuery(elem).data('cc_attach') != '1' && !jQuery(elem).prop('disabled')) {
-			jQuery(elem).data('cc_attach', '1');
+	document.querySelectorAll('[name="postcode"]').forEach(function(elem) {
+		if (elem.dataset.cc_attach != '1' && !elem.disabled) {
+			elem.dataset.cc_attach = '1';
+			var form = elem.closest('.admin__fieldset');
 
-			var form = jQuery(elem).closest('.admin__fieldset');
-			var tmp_html = '<div class="admin__field"><label class="admin__field-label">' + c2a_config.autocomplete.texts.search_label + '</label><div class="admin__field-control"><input class="cc_search_input admin__control-text" type="text"/></div></div>';
-			form.find('[name="street[0]"]').closest('div.admin__field').before(tmp_html);
+			var search_elem = document.createElement('input');
+			search_elem.classList.add('cc_search_input', 'admin__control-text');
+			search_elem.setAttribute('type', 'text');
+
+			var small_wrapper_elem = document.createElement('div');
+			small_wrapper_elem.classList.add('admin__field-control');
+			small_wrapper_elem.appendChild(search_elem);
+
+			var label_elem = document.createElement('label');
+			label_elem.classList.add('admin__field-label');
+			label_elem.textContent = c2a_config.autocomplete.texts.search_label;
+
+			var big_wrapper_elem = document.createElement('div');
+			big_wrapper_elem.classList.add('admin__field');
+			big_wrapper_elem.appendChild(label_elem);
+			big_wrapper_elem.appendChild(small_wrapper_elem);
+
+			form.querySelector('[name="street[0]"]').closest('div.admin__field').before(big_wrapper_elem);
 
 			window.cc_holder.attach({
-				search:		form.find('.cc_search_input')[0],
-				company:	form.find('[name="company"]')[0],
-				line_1:		form.find('[name="street[0]"]')[0],
-				line_2:		form.find('[name="street[1]"]')[0],
-				postcode:	form.find('[name="postcode"]')[0],
-				town:		form.find('[name="city"]')[0],
+				search:		form.querySelector('.cc_search_input'),
+				company:	form.querySelector('[name="company"]'),
+				line_1:		form.querySelector('[name="street[0]"]'),
+				line_2:		form.querySelector('[name="street[1]"]'),
+				postcode:	form.querySelector('[name="postcode"]'),
+				town:		form.querySelector('[name="city"]'),
 				county:		{
-					input:	form.find('[name="region"]'),
-					list:	form.find('[name="region_id"]')
+					input:	form.querySelector('[name="region"]'),
+					list:	form.querySelector('[name="region_id"]')
 				},
-				country:	form.find('[name="country_id"]')[0]
+				country:	form.querySelector('[name="country_id"]')
 			});
 
 			cc_index++;
@@ -29,41 +46,6 @@ function activate_cc_m2() {
 // Postcode Lookup
 function activate_cc_m2_uk() {
 	if (c2a_config.postcodelookup.enabled) {
-		var cfg = {
-			id: '',
-			core: {
-				key: c2a_config.main.key,
-				preformat: true,
-				capsformat: {
-					address: true,
-					organization: true,
-					county: true,
-					town: true
-				}
-			},
-			dom: {},
-			sort_fields: {
-				active: true,
-				parent: 'div.admin__field'
-			},
-			txt: c2a_config.postcodelookup.txt,
-			error_msg: c2a_config.postcodelookup.error_msg,
-			county_data: c2a_config.postcodelookup.advanced.county_data,
-			ui: {
-				onResultSelected: function(dataset, id, fields) {
-					if (cfg.county_data == 'former_postal') {
-						fields.county[0].value = dataset.postal_county;
-					} else if (cfg.county_data == 'traditional') {
-						fields.county[0].value = dataset.traditional_county;
-					} else {
-						fields.county[0].value = '';
-					}
-					fields.county.trigger('change');
-					fields.address_4.val('').change;
-				}
-			}
-		};
-
 		var dom = {
 			company:	'[name="company"]',
 			address_1:	'[name="street[0]"]',
@@ -77,44 +59,101 @@ function activate_cc_m2_uk() {
 			country:	'[name="country_id"]'
 		};
 
-		var postcode_elements = jQuery(dom.postcode);
-		postcode_elements.each(function(index) {
-			if (postcode_elements.eq(index).data('cc') != '1') {
-				var active_cfg = {};
-				jQuery.extend(active_cfg, cfg);
-				active_cfg.id = 'm2_' + cc_index;
-				cc_index++;
+		document.querySelectorAll(dom.postcode).forEach(function(postcode_elem) {
+			if (postcode_elem.dataset.cc != '1') {
+				var form = postcode_elem.closest('.admin__fieldset');
 
-				var form = postcode_elements.eq(index).closest('.admin__fieldset');
-				active_cfg.dom = {
-					company:		form.find(dom.company),
-					address_1:		form.find(dom.address_1),
-					address_2:		form.find(dom.address_2),
-					address_3:		form.find(dom.address_3),
-					address_4:		form.find(dom.address_4),
-					postcode:		postcode_elements.eq(index),
-					town:			form.find(dom.town),
-					county:			form.find(dom.county),
-					county_list:	form.find(dom.county_list),
-					country:		form.find(dom.country)
+				var active_cfg = {
+					id: 'm2_' + cc_index,
+					core: {
+						key: c2a_config.main.key,
+						preformat: true,
+						capsformat: {
+							address: true,
+							organization: true,
+							county: true,
+							town: true
+						}
+					},
+					dom: {
+						company:		form.querySelector(dom.company),
+						address_1:		form.querySelector(dom.address_1),
+						address_2:		form.querySelector(dom.address_2),
+						address_3:		form.querySelector(dom.address_3),
+						address_4:		form.querySelector(dom.address_4),
+						postcode:		postcode_elem,
+						town:			form.querySelector(dom.town),
+						county:			form.querySelector(dom.county),
+						county_list:	form.querySelector(dom.county_list),
+						country:		form.querySelector(dom.country)
+					},
+					sort_fields: {
+						active: true,
+						parent: 'div.admin__field'
+					},
+					txt: c2a_config.postcodelookup.txt,
+					error_msg: c2a_config.postcodelookup.error_msg,
+					county_data: c2a_config.postcodelookup.advanced.county_data,
+					ui: {
+						onResultSelected: function(dataset, id, fields) {
+							if (active_cfg.county_data == 'former_postal') {
+								fields.county.value = dataset.postal_county;
+							} else if (active_cfg.county_data == 'traditional') {
+								fields.county.value = dataset.traditional_county;
+							} else {
+								fields.county.value = '';
+							}
+							fields.county.dispatchEvent(new Event('change'));;
+							if (fields.address_4) {
+								fields.address_4.value = '';
+								fields.address_4.dispatchEvent(new Event('change'));
+							}
+						}
+					}
 				};
 
+				cc_index++;
+
 				// modify the Layout
-				var postcode_elem = active_cfg.dom.postcode;
-				postcode_elem.wrap('<div class="search-bar"></div>');
-				postcode_elem.after('<button type="button" class="action primary">' +
-					'<span>' + active_cfg.txt.search_buttontext + '</span></button>');
+				var button_text_elem = document.createElement('span');
+				button_text_elem.textContent = active_cfg.txt.search_buttontext;
+
+				var button_elem = document.createElement('button');
+				button_elem.setAttribute('type', 'button');
+				button_elem.classList.add('action', 'primary');
+				button_elem.appendChild(button_text_elem);
+
+				var postcode_wrapper_elem = document.createElement('div');
+				postcode_wrapper_elem.classList.add('search-bar');
+				postcode_elem.replaceWith(postcode_wrapper_elem);
+				postcode_wrapper_elem.appendChild(postcode_elem);
+				postcode_wrapper_elem.appendChild(button_elem);
 
 				// ADMIN
-				postcode_elem.closest('.search-bar').after('<div class="search-list" style="display: none;">' +
-					'<select class="admin__control-select"></select>' +
-					'</div><div class="mage-error" generated><div class="search-subtext"></div></div>');
+				var error_elem = document.createElement('div');
+				error_elem.classList.add('search-subtext');
+
+				var error_wrapper_elem = document.createElement('div');
+				error_wrapper_elem.classList.add('mage-error');
+				error_wrapper_elem.setAttribute('generated', '');
+				error_wrapper_elem.appendChild(error_elem);
+				postcode_wrapper_elem.after(error_wrapper_elem);
+
+				var results_elem = document.createElement('select');
+				results_elem.classList.add('admin__control-select');
+
+				var results_wrapper_elem = document.createElement('div');
+				results_wrapper_elem.classList.add('search-list');
+				results_wrapper_elem.style.display = 'none';
+				results_wrapper_elem.appendChild(results_elem);
+				postcode_wrapper_elem.after(results_wrapper_elem);
 
 				// input after postcode
 				var new_container = postcode_elem.closest(active_cfg.sort_fields.parent);
-				new_container.addClass('search-container').attr('id', active_cfg.id).addClass('type_3');
+				new_container.id = active_cfg.id;
+				new_container.classList.add('search-container', 'type_3');
 
-				active_cfg.dom.postcode.data('cc', '1');
+				active_cfg.dom.postcode.dataset.cc = '1';
 
 				var cc_generic = new cc_ui_handler(active_cfg);
 				cc_generic.activate();
@@ -126,167 +165,154 @@ function activate_cc_m2_uk() {
 var cc_index = 0;
 
 window.cc_holder = null;
-requirejs(['jquery'], function($) {
-	jQuery(document).ready(function() {
-		if (!c2a_config.main.enable_extension) { return; }
+function cc_init() {
+	if (!c2a_config.main.enable_extension) { return; }
 
-		if (c2a_config.autocomplete.enabled && c2a_config.main.key != null) {
-			var config = {
-				accessToken: c2a_config.main.key,
-				onSetCounty: function(c2a, elements, county) {
-					if ('createEvent' in document) {
-						var evt = document.createEvent('HTMLEvents');
-						evt.initEvent('change', false, true);
-						elements.country.dispatchEvent(evt);
-					} else {
-						elements.country.fireEvent('onchange');
-					}
+	if (c2a_config.autocomplete.enabled && c2a_config.main.key != null) {
+		var config = {
+			accessToken: c2a_config.main.key,
+			onSetCounty: function(c2a, elements, county) {
+				elements.country.dispatchEvent(new Event('change'));
 
-					if (c2a.activeCountry === 'gbr' && !c2a_config.autocomplete.advanced.fill_uk_counties) {
-						c2a.setCounty(elements.county.list[0], { code: '', name: '', preferred: '' });
-						c2a.setCounty(elements.county.input[0], { code: '', name: '', preferred: '' });
-					} else {
-						c2a.setCounty(elements.county.list[0], county);
-						c2a.setCounty(elements.county.input[0], county);
-					}
-				},
-				domMode: 'object',
-				gfxMode: c2a_config.autocomplete.gfx_mode,
-				style: {
-					ambient: c2a_config.autocomplete.gfx_ambient,
-					accent: c2a_config.autocomplete.gfx_accent
-				},
-				onResultSelected: function(c2a, elements, address) {
-					var postcode = address.postal_code.substring(0, 2);
-
-					switch (postcode) {
-						case 'JE':
-						case 'GG':
-						case 'IM':
-							jQuery(elements.country).val(postcode);
-							break;
-						default:
-							jQuery(elements.country).val(address.country.iso_3166_1_alpha_2);
-					}
-
-					// county input value will be lost when country change event triggered so save it for later
-					var county_input_val = jQuery(elements.county.input).val();
-
-					jQuery(elements.country).trigger('change');
-					jQuery(elements.company).trigger('change');
-					jQuery(elements.line_1).trigger('change');
-					jQuery(elements.line_2).trigger('change');
-					jQuery(elements.postcode).trigger('change');
-					jQuery(elements.town).trigger('change');
-					jQuery(elements.county.input).val(county_input_val).trigger('change');
-
-					// only trigger change on list if it's visible, otherwise county input val will be lost
-					if (jQuery(elements.county.list).css('display') != 'none') {
-						jQuery(elements.county.list).trigger('change');
-					}
-					
-					var line_3 = jQuery(elements.search).closest('form').find('[name="street[2]"]');
-					if (line_3.length !== 0) {
-						line_3.val('');
-						triggerEvent('change', line_3[0]);
-					}
-					
-					var line_4 = jQuery(elements.search).closest('form').find('[name="street[3]"]');
-					if (line_4.length !== 0) {
-						line_4.val('');
-						triggerEvent('change', line_4[0]);
-					}
-				},
-				showLogo: false,
-				texts: c2a_config.autocomplete.texts,
-				transliterate: c2a_config.autocomplete.advanced.transliterate,
-				excludeAreas: c2a_config.autocomplete.exclusions.areas,
-				excludePoBox: c2a_config.autocomplete.exclusions.po_box,
-				debug: c2a_config.autocomplete.advanced.debug,
-				cssPath: false,
-				tag: 'Magento 2 - int'
-			};
-
-			if (typeof c2a_config.autocomplete.enabled_countries !== 'undefined') {
-				config.countryMatchWith = 'iso_2';
-
-				var countryList = [];
-				var countryOptions = jQuery('#country_id').find('option');
-
-				for (var i = 1; i < countryOptions.length; i++) {
-					countryList.push(countryOptions[i].value);
-				}
-
-				var isSame = c2a_config.autocomplete.enabled_countries.every(function (country) {
-					return countryList.indexOf(country) > -1;
-				});
-
-				if (!isSame) {
-					config.enabledCountries = countryList;
+				if (c2a.activeCountry === 'gbr' && !c2a_config.autocomplete.advanced.fill_uk_counties) {
+					c2a.setCounty(elements.county.list, { code: '', name: '', preferred: '' });
+					c2a.setCounty(elements.county.input, { code: '', name: '', preferred: '' });
 				} else {
-					config.enabledCountries = c2a_config.autocomplete.enabled_countries;
+					c2a.setCounty(elements.county.list, county);
+					c2a.setCounty(elements.county.input, county);
 				}
+			},
+			domMode: 'object',
+			gfxMode: c2a_config.autocomplete.gfx_mode,
+			style: {
+				ambient: c2a_config.autocomplete.gfx_ambient,
+				accent: c2a_config.autocomplete.gfx_accent
+			},
+			onResultSelected: function(c2a, elements, address) {
+				var postcode = address.postal_code.substring(0, 2);
+
+				switch (postcode) {
+					case 'JE':
+					case 'GG':
+					case 'IM':
+						elements.country.value = postcode;
+						break;
+					default:
+						elements.country.value = address.country.iso_3166_1_alpha_2;
+				}
+
+				// county input value will be lost when country change event triggered so save it for later
+				var county_input_val = elements.county.input.value;
+
+				elements.country.dispatchEvent(new Event('change'));
+				elements.company.dispatchEvent(new Event('change'));
+				elements.line_1.dispatchEvent(new Event('change'));
+				elements.line_2.dispatchEvent(new Event('change'));
+				elements.postcode.dispatchEvent(new Event('change'));
+				elements.town.dispatchEvent(new Event('change'));
+				elements.county.input.value = county_input_val;
+				elements.county.input.dispatchEvent(new Event('change'));
+
+				// only trigger change on list if it's visible, otherwise county input val will be lost
+				if (elements.county.list.checkVisibility()) {
+					elements.county.list.dispatchEvent(new Event('change'));
+				}
+
+				var line_3 = elements.search.closest('form').querySelector('[name="street[2]"]');
+				if (line_3) {
+					line_3.value = '';
+					line_3.dispatchEvent(new Event('change'));
+				}
+				
+				var line_4 = elements.search.closest('form').querySelector('[name="street[3]"]');
+				if (line_4) {
+					line_4.value = '';
+					line_4.dispatchEvent(new Event('change'));
+				}
+			},
+			showLogo: false,
+			texts: c2a_config.autocomplete.texts,
+			transliterate: c2a_config.autocomplete.advanced.transliterate,
+			excludeAreas: c2a_config.autocomplete.exclusions.areas,
+			excludePoBox: c2a_config.autocomplete.exclusions.po_box,
+			debug: c2a_config.autocomplete.advanced.debug,
+			cssPath: false,
+			tag: 'Magento 2 - int'
+		};
+
+		if (typeof c2a_config.autocomplete.enabled_countries !== 'undefined') {
+			config.countryMatchWith = 'iso_2';
+
+			var countryList = [];
+			var countryOptions = document.getElementById('country_id').querySelectorAll('option');
+
+			for (var i = 1; i < countryOptions.length; i++) {
+				countryList.push(countryOptions[i].value);
 			}
 
-			if (c2a_config.autocomplete.advanced.lock_country_to_dropdown) {
-				config.countrySelector = false;
-				config.onSearchFocus = function(c2a, dom) {
-					var currentCountry = dom.country.options[dom.country.selectedIndex].value;
-					if (currentCountry !== '') {
-						var countryCode = getCountryCode(c2a, currentCountry, 'iso_2');
-						c2a.selectCountry(countryCode);
-					}
-				};
+			var isSame = c2a_config.autocomplete.enabled_countries.every(function (country) {
+				return countryList.indexOf(country) > -1;
+			});
+
+			if (!isSame) {
+				config.enabledCountries = countryList;
+			} else {
+				config.enabledCountries = c2a_config.autocomplete.enabled_countries;
 			}
-
-			window.cc_holder = new clickToAddress(config);
-
-			setInterval(activate_cc_m2, 200);
 		}
 
-		if (c2a_config.autocomplete.enabled && c2a_config.main.key == null) {
-			console.warn('ClickToAddress: Incorrect token format supplied');
+		if (c2a_config.autocomplete.advanced.lock_country_to_dropdown) {
+			config.countrySelector = false;
+			config.onSearchFocus = function(c2a, dom) {
+				var currentCountry = dom.country.options[dom.country.selectedIndex].value;
+				if (currentCountry !== '') {
+					var countryCode = getCountryCode(c2a, currentCountry, 'iso_2');
+					c2a.selectCountry(countryCode);
+				}
+			};
 		}
 
-		if (c2a_config.postcodelookup.enabled) {
-			setInterval(activate_cc_m2_uk, 200);
-		}
+		window.cc_holder = new clickToAddress(config);
 
-		if (c2a_config.phonevalidation.enabled && c2a_config.main.key != null) {
-			if (window.cc_holder == null) {
-				window.cc_holder = new clickToAddress({
-					accessToken: c2a_config.main.key,
-				});
-			}
-			
-			setInterval(function() {
-				var phone_elements = jQuery('input[name="telephone"]');
-				phone_elements.each(function(index) {
-					var phone_element = phone_elements.eq(index);
-					if (phone_element.data('cc') != '1') {
-						var country = phone_element.closest('form').find('select[name="country_id"]');
-						if (country.length > 0) {
-							window.cc_holder.addPhoneVerify({
-								phone: phone_element[0],
-								country: country[0]
-							});
-							phone_element.data('cc', '1');
-						}
-					}
-				});
-			}, 200);
-		}
-	});
-});
-
-// IE11 compatibility
-function triggerEvent(eventName, target) {
-	var event;
-	if (typeof (Event) === 'function') {
-		event = new Event(eventName);
-	} else {
-		event = document.createEvent('Event');
-		event.initEvent(eventName, true, true);
+		setInterval(activate_cc_m2, 200);
 	}
-	target.dispatchEvent(event);
+
+	if (c2a_config.autocomplete.enabled && c2a_config.main.key == null) {
+		console.warn('ClickToAddress: Incorrect token format supplied');
+	}
+
+	if (c2a_config.postcodelookup.enabled) {
+		setInterval(activate_cc_m2_uk, 200);
+	}
+
+	if (c2a_config.phonevalidation.enabled && c2a_config.main.key != null) {
+		if (window.cc_holder == null) {
+			window.cc_holder = new clickToAddress({
+				accessToken: c2a_config.main.key,
+			});
+		}
+		
+		setInterval(function() {
+			document.querySelectorAll('input[name="telephone"]').forEach(function(phone_element) {
+				if (phone_element.dataset.cc != '1') {
+					var country = phone_element.closest('form').querySelector('select[name="country_id"]');
+					if (country) {
+						window.cc_holder.addPhoneVerify({
+							phone: phone_element,
+							country: country
+						});
+						phone_element.dataset.cc = '1';
+					}
+				}
+			});
+		}, 200);
+	}
 }
+
+requirejs(['jquery'], function($) {
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', cc_init);
+	} else {
+		cc_init();
+	}
+});

--- a/view/adminhtml/web/form_integrations/cc_admin_order_create_customer.js
+++ b/view/adminhtml/web/form_integrations/cc_admin_order_create_customer.js
@@ -1,27 +1,46 @@
 var cc_activate_flags = [];
 
+// address autocomplete
 function activate_cc_m2() {
-	jQuery('[name$="_address][postcode]"]').each(function(index, elem) {
-		if (jQuery(elem).data('cc_attach') != '1' && !jQuery(elem).prop('disabled')) {
-			jQuery(elem).data('cc_attach', '1');
+	document.querySelectorAll('[name$="_address][postcode]"]').forEach((elem, index) => {
+		if (elem.dataset.cc_attach != '1' && !elem.disabled) {
+			elem.dataset.cc_attach = '1';
 
-			var form = jQuery(elem).closest('fieldset');
-			var tmp_html = '<div class="admin__field"><label class="admin__field-label">' + c2a_config.autocomplete.texts.search_label + '</label><div class="admin__field-control"><input id="cc_' + cc_index + '_search_input" class="cc_search_bar admin__control-text" type="text"/></div></div>';
-			form.find('[name$="_address][street][0]"]').closest('div.admin__field').before(tmp_html);
-			form.attr('id', 'cc-fieldset-' + index);
+			var form = elem.closest('fieldset');
+
+			var search_elem = document.createElement('input');
+			search_elem.id = 'cc_' + cc_index + '_search_input';
+			search_elem.classList.add('cc_search_bar', 'admin__control-text');
+			search_elem.setAttribute('type', 'text');
+
+			var small_wrapper_elem = document.createElement('div');
+			small_wrapper_elem.classList.add('admin__field-control');
+			small_wrapper_elem.appendChild(search_elem);
+
+			var label_elem = document.createElement('label');
+			label_elem.classList.add('admin__field-label');
+			label_elem.textContent = c2a_config.autocomplete.texts.search_label;
+
+			var big_wrapper_elem = document.createElement('div');
+			big_wrapper_elem.classList.add('admin__field');
+			big_wrapper_elem.appendChild(label_elem);
+			big_wrapper_elem.appendChild(small_wrapper_elem);
+
+			form.querySelector('[name$="_address][street][0]"]').closest('div.admin__field').before(big_wrapper_elem);
+			form.id = 'cc-fieldset-' + index;
 
 			window.cc_holder.attach({
-				search:		form.find('#cc_' + cc_index + '_search_input')[0],
-				company:	form.find('[name$="_address][company]"]')[0],
-				line_1:		form.find('[name$="_address][street][0]"]')[0],
-				line_2:		form.find('[name$="_address][street][1]"]')[0],
-				postcode:	form.find('[name$="_address][postcode]"]')[0],
-				town:		form.find('[name$="_address][city]"]')[0],
+				search:		form.querySelector('#cc_' + cc_index + '_search_input'),
+				company:	form.querySelector('[name$="_address][company]"]'),
+				line_1:		form.querySelector('[name$="_address][street][0]"]'),
+				line_2:		form.querySelector('[name$="_address][street][1]"]'),
+				postcode:	form.querySelector('[name$="_address][postcode]"]'),
+				town:		form.querySelector('[name$="_address][city]"]'),
 				county:		{
-					input:	form.find('[name$="_address][region]"]'),
-					list:	form.find('[name$="_address][region_id]"]'),
+					input:	form.querySelector('[name$="_address][region]"]'),
+					list:	form.querySelector('[name$="_address][region_id]"]'),
 				},
-				country:	form.find('select[name$="_address][country_id]"]')[0]
+				country:	form.querySelector('select[name$="_address][country_id]"]')
 			});
 			
 			cc_index++;
@@ -35,33 +54,6 @@ var cc_index = 0;
 var cc_activate_flags = [];
 function activate_cc_m2_uk() {
 	if (c2a_config.postcodelookup.enabled) {
-		var cfg = {
-			id: '',
-			core: {
-				key: c2a_config.main.key,
-				preformat: true,
-				capsformat: {
-					address: true,
-					organization: true,
-					county: true,
-					town: true
-				}
-			},
-			dom: {},
-			sort_fields: {
-				active: true,
-				parent: 'div.admin__field'
-			},
-			txt: c2a_config.postcodelookup.txt,
-			error_msg: c2a_config.postcodelookup.error_msg,
-			county_data: c2a_config.postcodelookup.advanced.county_data,
-			ui: {
-				onResultSelected: function(dataset, id, fields) {
-					fields.address_4.val('').change();
-				}
-			}
-		};
-
 		var dom = {
 			company:	'[name$="_address][company]"]',
 			address_1:	'[name$="_address][street][0]"]',
@@ -75,45 +67,94 @@ function activate_cc_m2_uk() {
 			country:	'select[name$="_address][country_id]"]'
 		};
 
-		var postcode_elements = jQuery(dom.postcode);
-		postcode_elements.each(function(index) {
-			if (postcode_elements.eq(index).data('cc') != '1') {
-				var active_cfg = {};
-				jQuery.extend(active_cfg, cfg);
-				active_cfg.id = 'm2_' + cc_index;
-				cc_index++;
+		document.querySelectorAll(dom.postcode).forEach((postcode_elem) => {
+			if (postcode_elem.dataset.cc != '1') {
+				var form = postcode_elem.closest('fieldset');
 
-				var form = postcode_elements.eq(index).closest('fieldset');
-				active_cfg.dom = {
-					company: form.find(dom.company),
-					address_1: form.find(dom.address_1),
-					address_2: form.find(dom.address_2),
-					address_3: form.find(dom.address_3),
-					address_4: form.find(dom.address_4),
-					postcode: postcode_elements.eq(index),
-					town: form.find(dom.town),
-					county: form.find(dom.county),
-					county_list: form.find(dom.county_list),
-					country: form.find(dom.country)
+				var active_cfg = {
+					id: 'm2_' + cc_index,
+					core: {
+						key: c2a_config.main.key,
+						preformat: true,
+						capsformat: {
+							address: true,
+							organization: true,
+							county: true,
+							town: true
+						}
+					},
+					dom: {
+						company: form.querySelector(dom.company),
+						address_1: form.querySelector(dom.address_1),
+						address_2: form.querySelector(dom.address_2),
+						address_3: form.querySelector(dom.address_3),
+						address_4: form.querySelector(dom.address_4),
+						postcode: postcode_elem,
+						town: form.querySelector(dom.town),
+						county: form.querySelector(dom.county),
+						county_list: form.querySelector(dom.county_list),
+						country: form.querySelector(dom.country)
+					},
+					sort_fields: {
+						active: true,
+						parent: 'div.admin__field'
+					},
+					txt: c2a_config.postcodelookup.txt,
+					error_msg: c2a_config.postcodelookup.error_msg,
+					county_data: c2a_config.postcodelookup.advanced.county_data,
+					ui: {
+						onResultSelected: function(dataset, id, fields) {
+							if (fields.address_4) {
+								fields.address_4.value = '';
+								fields.address_4.dispatchEvent(new Event('change'));
+							}
+						}
+					}
 				};
 
+				cc_index++;
+
 				// modify the Layout
-				var postcode_elem = active_cfg.dom.postcode;
-				postcode_elem.wrap('<div class="search-bar"></div>');
-				postcode_elem.after('<button type="button" class="action primary">' +
-					'<span>' + active_cfg.txt.search_buttontext + '</span></button>');
+				var button_text_elem = document.createElement('span');
+				button_text_elem.textContent = active_cfg.txt.search_buttontext;
+
+				var button_elem = document.createElement('button');
+				button_elem.setAttribute('type', 'button');
+				button_elem.classList.add('action', 'primary');
+				button_elem.appendChild(button_text_elem);
+
+				var postcode_wrapper_elem = document.createElement('div');
+				postcode_wrapper_elem.classList.add('search-bar');
+				postcode_elem.replaceWith(postcode_wrapper_elem);
+				postcode_wrapper_elem.appendChild(postcode_elem);
+				postcode_wrapper_elem.appendChild(button_elem);
 
 				// ADMIN
-				postcode_elem.closest('.search-bar').after('<div class="search-list" style="display: none;">' +
-					'<select class="admin__control-select"></select>' +
-					'</div><div class="mage-error" generated><div class="search-subtext"></div></div>');
+				var error_elem = document.createElement('div');
+				error_elem.classList.add('search-subtext');
+
+				var error_wrapper_elem = document.createElement('div');
+				error_wrapper_elem.classList.add('mage-error');
+				error_wrapper_elem.setAttribute('generated', '');
+				error_wrapper_elem.appendChild(error_elem);
+				postcode_wrapper_elem.after(error_wrapper_elem);
+
+				var results_elem = document.createElement('select');
+				results_elem.classList.add('admin__control-select');
+
+				var results_wrapper_elem = document.createElement('div');
+				results_wrapper_elem.classList.add('search-list');
+				results_wrapper_elem.style.display = 'none';
+				results_wrapper_elem.appendChild(results_elem);
+				postcode_wrapper_elem.after(results_wrapper_elem);
 
 				// input after postcode
 				var new_container = postcode_elem.closest(active_cfg.sort_fields.parent);
-				new_container.addClass('search-container').attr('id', active_cfg.id).addClass('type_3');
+				new_container.id = active_cfg.id;
+				new_container.classList.add('search-container', 'type_3');
 
 				active_cfg.ui.top_elem = 'div.admin__page-section-item';
-				active_cfg.dom.postcode.data('cc', '1');
+				active_cfg.dom.postcode.dataset.cc = '1';
 
 				var cc_generic = new cc_ui_handler(active_cfg);
 				cc_generic.activate();
@@ -125,144 +166,170 @@ function activate_cc_m2_uk() {
 var cc_index = 0;
 
 window.cc_holder = null;
-requirejs(['jquery'], function($) {
-	jQuery(document).ready(function() {
-		if (!c2a_config.main.enable_extension) { return; }
+function cc_init() {
+	if (!c2a_config.main.enable_extension) { return; }
 
-		if (c2a_config.autocomplete.enabled && c2a_config.main.key != null) {
-			var config = {
-				accessToken: c2a_config.main.key,
-				onSetCounty: function(c2a, elements, county) {
-					if ('createEvent' in document) {
-						var evt = document.createEvent('HTMLEvents');
-						evt.initEvent('change', false, true);
-						elements.country.dispatchEvent(evt);
+	if (c2a_config.autocomplete.enabled && c2a_config.main.key != null) {
+		var config = {
+			accessToken: c2a_config.main.key,
+			onSetCounty: function(c2a, elements, county) {
+				setTimeout(function() {
+					if (c2a.activeCountry === 'gbr' && !c2a_config.autocomplete.advanced.fill_uk_counties) {
+						c2a.setCounty(elements.county.list, { code: '', name: '', preferred: '' });
+						c2a.setCounty(elements.county.input, { code: '', name: '', preferred: '' });
 					} else {
-						elements.country.fireEvent('onchange');
+						c2a.setCounty(elements.county.list, county);
+						c2a.setCounty(elements.county.input, county);
 					}
 
-					setTimeout(function() {
-						if (c2a.activeCountry === 'gbr' && !c2a_config.autocomplete.advanced.fill_uk_counties) {
-							c2a.setCounty(elements.county.list[0], { code: '', name: '', preferred: '' });
-							c2a.setCounty(elements.county.input[0], { code: '', name: '', preferred: '' });
-						} else {
-							c2a.setCounty(elements.county.list[0], county);
-							c2a.setCounty(elements.county.input[0], county);
-						}
-					}, 100);
-				},
-				domMode: 'object',
-				gfxMode: c2a_config.autocomplete.gfx_mode,
-				style: {
-					ambient: c2a_config.autocomplete.gfx_ambient,
-					accent: c2a_config.autocomplete.gfx_accent
-				},
-				onResultSelected: function(c2a, elements, address) {
-					var postcode = address.postal_code.substring(0, 2);
+					if (elements.county.input) elements.county.input.dispatchEvent(new Event('change'));
 
-					switch (postcode) {
-						case 'JE':
-						case 'GG':
-						case 'IM':
-							jQuery(elements.country).val(postcode);
-							break;
-						default:
-							jQuery(elements.country).val(address.country.iso_3166_1_alpha_2);
+					// only trigger change on list if it's visible, otherwise county input val will be lost
+					if (elements.county.list && elements.county.list.checkVisibility()) {
+						elements.county.list.dispatchEvent(new Event('change'));
 					}
+				}, 100);
+			},
+			domMode: 'object',
+			gfxMode: c2a_config.autocomplete.gfx_mode,
+			style: {
+				ambient: c2a_config.autocomplete.gfx_ambient,
+				accent: c2a_config.autocomplete.gfx_accent
+			},
+			onResultSelected: function(c2a, elements, address) {
+				var postcode = address.postal_code.substring(0, 2);
 
-					jQuery(elements.country).trigger('change');
+				switch (postcode) {
+					case 'JE':
+					case 'GG':
+					case 'IM':
+						elements.country.value = postcode;
+						break;
+					default:
+						elements.country.value = address.country.iso_3166_1_alpha_2;
+				}
 
-					var line_3 = jQuery(elements.search).closest('form').find('[name="street[2]"]');
-					if (line_3.length !== 0) {
-						line_3.val('');
-						triggerEvent('change', line_3[0]);
-					}
-					
-					var line_4 = jQuery(elements.search).closest('form').find('[name="street[3]"]');
-					if (line_4.length !== 0) {
-						line_4.val('');
-						triggerEvent('change', line_4[0]);
-					}
-				},
-				showLogo: false,
-				texts: c2a_config.autocomplete.texts,
-				transliterate: c2a_config.autocomplete.advanced.transliterate,
-				excludeAreas: c2a_config.autocomplete.exclusions.areas,
-				excludePoBox: c2a_config.autocomplete.exclusions.po_box,
-				debug: c2a_config.autocomplete.advanced.debug,
-				cssPath: false,
-				tag: 'Magento 2 - int'
+				if (elements.country) elements.country.dispatchEvent(new Event('change'));
+				if (elements.company) elements.company.dispatchEvent(new Event('change'));
+				if (elements.line_1) elements.line_1.dispatchEvent(new Event('change'));
+				if (elements.line_2) elements.line_2.dispatchEvent(new Event('change'));
+				if (elements.postcode) elements.postcode.dispatchEvent(new Event('change'));
+				if (elements.town) elements.town.dispatchEvent(new Event('change'));
+
+				var line_3 = elements.search.closest('fieldset').querySelector('[name$="_address][street][2]"]');
+				if (line_3) {
+					line_3.value = '';
+					line_3.dispatchEvent(new Event('change'));
+				}
+				
+				var line_4 = elements.search.closest('fieldset').querySelector('[name$="_address][street][3]"]');
+				if (line_4) {
+					line_4.value = '';
+					line_4.dispatchEvent(new Event('change'));
+				}
+			},
+			showLogo: false,
+			texts: c2a_config.autocomplete.texts,
+			transliterate: c2a_config.autocomplete.advanced.transliterate,
+			excludeAreas: c2a_config.autocomplete.exclusions.areas,
+			excludePoBox: c2a_config.autocomplete.exclusions.po_box,
+			debug: c2a_config.autocomplete.advanced.debug,
+			cssPath: false,
+			tag: 'Magento 2 - int'
+		};
+
+		if (typeof c2a_config.autocomplete.enabled_countries !== 'undefined') {
+			config.countryMatchWith = 'iso_2';
+			
+			var countryList = [];
+			var countryOptions = document.getElementById('order-billing_address_country_id').querySelectorAll('option');
+
+			for (var i = 1; i < countryOptions.length; i++) {
+				countryList.push(countryOptions[i].value);
+			}
+
+			var isSame = true;
+
+			var isSame = c2a_config.autocomplete.enabled_countries.every(function (country) {
+				return countryList.indexOf(country) > -1;
+			});
+			
+			if (!isSame) {
+				config.enabledCountries = countryList;
+			} else {
+				config.enabledCountries = c2a_config.autocomplete.enabled_countries;
+			}
+		}
+
+		if (c2a_config.autocomplete.advanced.lock_country_to_dropdown) {
+			config.countrySelector = false;
+			config.onSearchFocus = function(c2a, dom) {
+				var currentCountry = dom.country.options[dom.country.selectedIndex].value;
+				if (currentCountry !== '') {
+					var countryCode = getCountryCode(c2a, currentCountry, 'iso_2');
+					c2a.selectCountry(countryCode);
+				}
 			};
+		}
 
-			if (typeof c2a_config.autocomplete.enabled_countries !== 'undefined') {
-				config.countryMatchWith = 'iso_2';
-				
-				var countryList = [];
-				var countryOptions = jQuery('#order-billing_address_country_id').find('option');
+		window.cc_holder = new clickToAddress(config);
+		setInterval(activate_cc_m2, 200);
+	}
 
-				for (var i = 1; i < countryOptions.length; i++) {
-					countryList.push(countryOptions[i].value);
-				}
+	if (c2a_config.autocomplete.enabled && c2a_config.main.key == null) {
+		console.warn('ClickToAddress: Incorrect token format supplied');
+	}
 
-				var isSame = true;
+	if (c2a_config.postcodelookup.enabled) {
+		setInterval(activate_cc_m2_uk, 200);
+	}
 
-				var isSame = c2a_config.autocomplete.enabled_countries.every(function (country) {
-					return countryList.indexOf(country) > -1;
+	if (c2a_config.emailvalidation.enabled && c2a_config.main.key != null) {
+		if (window.cc_holder == null) {
+			window.cc_holder = new clickToAddress({
+				accessToken: c2a_config.main.key,
+			});
+		}
+
+		setInterval(function() {
+			var email_element = document.querySelector('input[name$="[email]"]');
+			if (email_element.dataset.cc != '1') {
+				email_element.dataset.cc = '1';
+				window.cc_holder.addEmailVerify({
+					email: email_element
 				});
-				
-				if (!isSame) {
-					config.enabledCountries = countryList;
-				} else {
-					config.enabledCountries = c2a_config.autocomplete.enabled_countries;
-				}
 			}
+		}, 200);
+	}
 
-			if (c2a_config.autocomplete.advanced.lock_country_to_dropdown) {
-				config.countrySelector = false;
-				config.onSearchFocus = function(c2a, dom) {
-					var currentCountry = dom.country.options[dom.country.selectedIndex].value;
-					if (currentCountry !== '') {
-						var countryCode = getCountryCode(c2a, currentCountry, 'iso_2');
-						c2a.selectCountry(countryCode);
+	if (c2a_config.phonevalidation.enabled && c2a_config.main.key != null) {
+		if (window.cc_holder == null) {
+			window.cc_holder = new clickToAddress({
+				accessToken: c2a_config.main.key,
+			});
+		}
+
+		setInterval(function() {
+			document.querySelectorAll('input[name$="[telephone]"]').forEach(function(phone_element) {
+				if (phone_element.dataset.cc != '1') {
+					var country = phone_element.closest('.admin__fieldset').querySelector('select[name$="[country_id]"]');
+					if (country) {
+						phone_element.dataset.cc = '1';
+						window.cc_holder.addPhoneVerify({
+							phone: phone_element,
+							country: country
+						});
 					}
-				};
-			}
+				}
+			});
+		}, 200);
+	}
+}
 
-			window.cc_holder = new clickToAddress(config);
-			setInterval(activate_cc_m2, 200);
-		}
-
-		if (c2a_config.autocomplete.enabled && c2a_config.main.key == null) {
-			console.warn('ClickToAddress: Incorrect token format supplied');
-		}
-
-		if (c2a_config.postcodelookup.enabled) {
-			setInterval(activate_cc_m2_uk, 200);
-		}
-
-		if (c2a_config.phonevalidation.enabled && c2a_config.main.key != null) {
-			if (window.cc_holder == null) {
-				window.cc_holder = new clickToAddress({
-					accessToken: c2a_config.main.key,
-				});
-			}
-
-			setInterval(function() {
-				var phone_elements = jQuery('input[name$="[telephone]"]');
-				phone_elements.each(function(index) {
-					var phone_element = phone_elements.eq(index);
-					if (phone_element.data('cc') != '1') {
-						var country = phone_element.closest('.admin__fieldset').find('select[name$="[country_id]"]');
-						if (country.length > 0) {
-							phone_element.data('cc', '1');
-							window.cc_holder.addPhoneVerify({
-								phone: phone_element[0],
-								country: country[0]
-							});
-						}
-					}
-				});
-			}, 200);
-		}
-	});
+requirejs(['jquery'], function($) {
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', cc_init);
+	} else {
+		cc_init();
+	}
 });

--- a/view/base/web/cc_ukpcl_lib.js
+++ b/view/base/web/cc_ukpcl_lib.js
@@ -259,13 +259,13 @@ function cc_ui_handler(cfg) {
 	this.cfg = cfg;
 
 	var lines = 0;
-	if (cfg.dom.address_1.length === 1) {
+	if (jQuery(cfg.dom.address_1).length === 1) {
 		lines++;
 	}
-	if (cfg.dom.address_2.length === 1) {
+	if (jQuery(cfg.dom.address_2).length === 1) {
 		lines++;
 	}
-	if (cfg.dom.address_3.length === 1) {
+	if (jQuery(cfg.dom.address_3).length === 1) {
 		lines++;
 	}
 	this.cfg.core.lines = lines;
@@ -279,11 +279,11 @@ function cc_ui_handler(cfg) {
 
 cc_ui_handler.prototype.sort = function(is_uk) {
 	var elems = this.cfg.dom;
-	var country = elems.country.parents(this.cfg.sort_fields.parent).last();
+	var country = jQuery(elems.country).parents(this.cfg.sort_fields.parent).last();
 	// Sort disabled; position country on top
-	var company = elems.company.parents(this.cfg.sort_fields.parent).last();
-	var line_1 = elems.address_1.parents(this.cfg.sort_fields.parent).last();
-	var postcode = elems.postcode.parents(this.cfg.sort_fields.parent).last();
+	var company = jQuery(elems.company).parents(this.cfg.sort_fields.parent).last();
+	var line_1 = jQuery(elems.address_1).parents(this.cfg.sort_fields.parent).last();
+	var postcode = jQuery(elems.postcode).parents(this.cfg.sort_fields.parent).last();
 	if (company.length) {
 		country.insertBefore(company);
 	} else {
@@ -302,7 +302,7 @@ cc_ui_handler.prototype.sort = function(is_uk) {
 		tagElement = ['company', 'address_1', 'town', 'county', 'county_list'];
 
 		for (var i = 0; i < tagElement.length; i++) {
-			elems[tagElement[i]].parents(this.cfg.sort_fields.parent).last().addClass('crafty_address_field');
+			jQuery(elems[tagElement[i]]).parents(this.cfg.sort_fields.parent).last().addClass('crafty_address_field');
 		}
 	}
 };
@@ -315,16 +315,16 @@ cc_ui_handler.prototype.country_change = function(country) {
 		}
 		this.search_object.parents(this.cfg.sort_fields.parent).last().show();
 		this.search_object.find('.search-bar .action').show();
-		this.cfg.dom.postcode.closest('form').find('.cp_manual_entry').show(200);
+		jQuery(this.cfg.dom.postcode).closest('form').find('.cp_manual_entry').show(200);
 	} else {
 		if (this.cfg.sort_fields.active) {
 			this.sort(false);
 		}
 		this.search_object.parents(this.cfg.sort_fields.parent).last().hide();
 		this.search_object.find('.search-bar .action').hide();
-		this.cfg.dom.postcode.closest('form').find('.cp_manual_entry').hide(200);
+		jQuery(this.cfg.dom.postcode).closest('form').find('.cp_manual_entry').hide(200);
 	}
-	if (this.cfg.hide_fields && (active_countries.indexOf(country) != -1) && (this.cfg.dom.postcode.val() === '')) {
+	if (this.cfg.hide_fields && (active_countries.indexOf(country) != -1) && (jQuery(this.cfg.dom.postcode).val() === '')) {
 		this.search_object.closest(this.cfg.sort_fields.parent).parent().find('.crafty_address_field').addClass('crafty_address_field_hidden');
 	} else {
 		this.search_object.closest(this.cfg.sort_fields.parent).parent().find('.crafty_address_field').removeClass('crafty_address_field_hidden');
@@ -334,10 +334,10 @@ cc_ui_handler.prototype.country_change = function(country) {
 cc_ui_handler.prototype.activate = function() {
 	this.addui();
 
-	this.country_change(this.cfg.dom.country.val());
+	this.country_change(jQuery(this.cfg.dom.country).val());
 	// transfer object to event scope
 	var that = this;
-	this.cfg.dom.country.on('change', function() {
+	jQuery(this.cfg.dom.country).on('change', function() {
 		// selected country
 		var sc = jQuery(this).val();
 		that.country_change(sc);
@@ -371,7 +371,7 @@ cc_ui_handler.prototype.lookup = function(postcode) {
 		return;
 	}
 	// hyva form refreshes on postcode change so we can't change the field before selecting a result
-	if (!this.cfg.disable_country_change) this.cfg.dom.postcode.val(dataset.postcode);
+	if (!this.cfg.disable_country_change) jQuery(this.cfg.dom.postcode).val(dataset.postcode);
 	var new_html = "";
 	results = ['Select Your Address'];
 	for (var i = 0; i < dataset.delivery_point_count; i++) {
@@ -551,8 +551,8 @@ cc_ui_handler.prototype.countyFiller = function(element, county_value) {
 cc_ui_handler.prototype.select = function(postcode, id) {
 	var dataset = this.cc_core.get_store(this.cc_core.clean_input(postcode));
 
-	this.cfg.dom.town.val(dataset.town);
-	this.cfg.dom.postcode.val(dataset.postcode);
+	jQuery(this.cfg.dom.town).val(dataset.town);
+	jQuery(this.cfg.dom.postcode).val(dataset.postcode);
 
 	var company_details = [];
 	if (dataset.delivery_points[id].department_name !== '') {
@@ -562,10 +562,10 @@ cc_ui_handler.prototype.select = function(postcode, id) {
 		company_details.push(dataset.delivery_points[id].organisation_name);
 	}
 
-	this.cfg.dom.company.val(company_details.join(', '));
+	jQuery(this.cfg.dom.company).val(company_details.join(', '));
 
 	for (var i = 1; i <= this.cfg.core.lines; i++) {
-		this.cfg.dom['address_' + i].val(dataset.delivery_points[id]['line_' + i]);
+		jQuery(this.cfg.dom['address_' + i]).val(dataset.delivery_points[id]['line_' + i]);
 	}
 	var county_line = '';
 	switch (this.cfg.county_data) {
@@ -577,31 +577,31 @@ cc_ui_handler.prototype.select = function(postcode, id) {
 			break;
 	}
 
-	this.countyFiller(this.cfg.dom.county, county_line);
-	this.countyFiller(this.cfg.dom.county_list, county_line);
+	this.countyFiller(jQuery(this.cfg.dom.county), county_line);
+	this.countyFiller(jQuery(this.cfg.dom.county_list), county_line);
 
 	// Change country according to postcode
-	if (typeof this.cfg.dom.country != 'undefined') {
+	if (typeof jQuery(this.cfg.dom.country) != 'undefined') {
 		var crown_dependencies = ['GY', 'JE', 'IM'];
 		var postcode_area = dataset.postcode.substring(0, 2);
 		switch (postcode_area) {
 			case 'GY':
-				if (this.cfg.dom.country.find('option[value="GG"]').length) {
-					this.cfg.dom.country.val('GG');
+				if (jQuery(this.cfg.dom.country).find('option[value="GG"]').length) {
+					jQuery(this.cfg.dom.country).val('GG');
 				}
 				break;
 			case 'JE':
-				if (this.cfg.dom.country.find('option[value="JE"]').length) {
-					this.cfg.dom.country.val('JE');
+				if (jQuery(this.cfg.dom.country).find('option[value="JE"]').length) {
+					jQuery(this.cfg.dom.country).val('JE');
 				}
 				break;
 			case 'IM':
-				if (this.cfg.dom.country.find('option[value="IM"]').length) {
-					this.cfg.dom.country.val('IM');
+				if (jQuery(this.cfg.dom.country).find('option[value="IM"]').length) {
+					jQuery(this.cfg.dom.country).val('IM');
 				}
 				break;
 			default:
-				this.cfg.dom.country.val('GB');
+				jQuery(this.cfg.dom.country).val('GB');
 		}
 	}
 	if (this.cfg.hide_fields) {
@@ -609,7 +609,7 @@ cc_ui_handler.prototype.select = function(postcode, id) {
 	}
 	// trigger change for checkout validation
 	jQuery.each(this.cfg.dom, function(index, name) {
-		name.trigger('change');
+		jQuery(name).trigger('change');
 	});
 
 	if (typeof this.cfg.ui.onResultSelected == 'function') {

--- a/view/frontend/web/form_integrations/cc_customer_address.js
+++ b/view/frontend/web/form_integrations/cc_customer_address.js
@@ -6,53 +6,64 @@ function cc_m2_c2a() {
 	 * (needed on sites that load page elements
 	 * via multiple ajax requests)
 	 */
-	if (jQuery('[name="postcode"]').length == 0) {
+	if (!document.querySelector('[name="postcode"]')) {
 		return;
 	}
 
-	var postcode_elem = jQuery('[name="postcode"]')[0];
+	var postcode_elem = document.querySelector('[name="postcode"]');
 
-	if (jQuery(postcode_elem).data('cc_attach') != '1') {
-		jQuery(postcode_elem).data('cc_attach', '1');
+	if (postcode_elem.dataset.cc_attach != '1') {
+		postcode_elem.dataset.cc_attach = '1';
 
-		var form = jQuery(postcode_elem).closest('form');
-		var custom_id = '';
-
-		if (c2a_config.autocomplete.advanced.search_elem_id !== null) {
-			custom_id = ' id="' + c2a_config.autocomplete.advanced.search_elem_id + '"';
-		}
+		var form = postcode_elem.closest('form');
 
 		// null fix for m2_1.1.16
 		if (c2a_config.autocomplete.texts.search_label == null) c2a_config.autocomplete.texts.search_label = '';
 
-		var tmp_html = '<div class="field"' + custom_id + '><label class="label" for="fetchify_search">' +
-			c2a_config.autocomplete.texts.search_label + '</label>' +
-			'<div class="control"><input class="cc_search_input" type="text" name="fetchify_search"/></div></div>';
+		var search_elem = document.createElement('input');
+		search_elem.classList.add('cc_search_input');
+		search_elem.name = 'fetchify_search';
+		search_elem.setAttribute('type', 'text');
+
+		var small_wrapper_elem = document.createElement('div');
+		small_wrapper_elem.classList.add('control');
+		small_wrapper_elem.appendChild(search_elem);
+
+		var label_elem = document.createElement('label');
+		label_elem.classList.add('label');
+		label_elem.setAttribute('for', 'fetchify_search');
+		label_elem.textContent = c2a_config.autocomplete.texts.search_label;
+
+		var big_wrapper_elem = document.createElement('div');
+		if (c2a_config.autocomplete.advanced.search_elem_id !== null) { big_wrapper_elem.id = c2a_config.autocomplete.advanced.search_elem_id; } // custom id
+		big_wrapper_elem.classList.add('field');
+		big_wrapper_elem.appendChild(label_elem);
+		big_wrapper_elem.appendChild(small_wrapper_elem);
 
 		if (!c2a_config.autocomplete.advanced.use_first_line) {
-			form.find('#street_1').closest('.field').before(tmp_html);
+			form.querySelector('#street_1').closest('.field').before(big_wrapper_elem);
 		} else {
-			form.find('#street_1').addClass('cc_search_input');
+			form.querySelector('#street_1').classList.add('cc_search_input');
 		}
 
 		if (c2a_config.autocomplete.advanced.lock_country_to_dropdown) {
-			form.find('.cc_search_input').closest('div.field').before(form.find('[name="country_id"]').closest('div.field'));
+			form.querySelector('.cc_search_input').closest('div.field').before(form.querySelector('[name="country_id"]').closest('div.field'));
 		}
 
 		var config = {
 			accessToken: c2a_config.main.key,
 			dom: {
-				search:		form.find('.cc_search_input')[0],
-				company:	form.find('[name="company"]')[0],
-				line_1:		form.find('#street_1')[0],
-				line_2:		form.find('#street_2')[0],
-				postcode:	form.find('[name="postcode"]')[0],
-				town:		form.find('[name="city"]')[0],
+				search:		form.querySelector('.cc_search_input'),
+				company:	form.querySelector('[name="company"]'),
+				line_1:		form.querySelector('#street_1'),
+				line_2:		form.querySelector('#street_2'),
+				postcode:	form.querySelector('[name="postcode"]'),
+				town:		form.querySelector('[name="city"]'),
 				county:		{
-					input:	form.find('[name="region"]'),
-					list:	form.find('[name="region_id"]')
+					input:	form.querySelector('[name="region"]'),
+					list:	form.querySelector('[name="region_id"]')
 				},
-				country:	form.find('[name="country_id"]')[0]
+				country:	form.querySelector('[name="country_id"]')
 			},
 			onSetCounty: function(c2a, elements, county) {
 				return;
@@ -72,13 +83,13 @@ function cc_m2_c2a() {
 					case 'JE':
 					case 'GG':
 					case 'IM':
-						jQuery(elements.country).val(postcode);
+						elements.country.value = postcode;
 						break;
 					default:
-						jQuery(elements.country).val(address.country.iso_3166_1_alpha_2);
+						elements.country.value = address.country.iso_3166_1_alpha_2;
 				}
 				
-				if (typeof elements.country != 'undefined') { triggerEvent('change', elements.country); }
+				if (typeof elements.country != 'undefined') { elements.country.dispatchEvent(new Event('change')); }
 
 				var county;
 				if (c2a.activeCountry === 'gbr' && !c2a_config.autocomplete.advanced.fill_uk_counties) {
@@ -91,33 +102,32 @@ function cc_m2_c2a() {
 					};
 				}
 
-				if (elements.county.list.length == 1) {
-					c2a.setCounty(elements.county.list[0], county);
+				if (elements.county.list) {
+					c2a.setCounty(elements.county.list, county);
 				}
 
-				if (elements.county.input.length == 1) {
-					c2a.setCounty(elements.county.input[0], county);
+				if (elements.county.input) {
+					c2a.setCounty(elements.county.input, county);
 				}
 
-				if (typeof elements.county.input[0] != 'undefined') triggerEvent('change', elements.county.input[0]);
-				if (typeof elements.county.list[0] != 'undefined') triggerEvent('change', elements.county.list[0]);
-				if (typeof elements.company != 'undefined') triggerEvent('change', elements.company);
-				if (typeof elements.line_1 != 'undefined') triggerEvent('change', elements.line_1);
-				if (typeof elements.line_2 != 'undefined') triggerEvent('change', elements.line_2);
-				if (typeof elements.postcode != 'undefined') triggerEvent('change', elements.postcode);
-				if (typeof elements.town != 'undefined') triggerEvent('change', elements.town);
+				if (elements.county.input) elements.county.input.dispatchEvent(new Event('change'));
+				if (elements.county.list) elements.county.list.dispatchEvent(new Event('change'));
+				if (elements.company) elements.company.dispatchEvent(new Event('change'));
+				if (elements.line_1) elements.line_1.dispatchEvent(new Event('change'));
+				if (elements.line_2) elements.line_2.dispatchEvent(new Event('change'));
+				if (elements.postcode) elements.postcode.dispatchEvent(new Event('change'));
+				if (elements.town) elements.town.dispatchEvent(new Event('change'));
 
+				var line_3 = elements.search.closest('form').querySelector('#street_3');
+				if (line_3) {
+					line_3.value = '';
+					elements.line_3.dispatchEvent(new Event('change'));
+				}
 				
-				var line_3 = jQuery(elements.search).closest('form').find('#street_3');
-				if (line_3.length !== 0) {
-					line_3.val('');
-					triggerEvent('change', line_3[0]);
-				}
-				
-				var line_4 = jQuery(elements.search).closest('form').find('#street_4');
-				if (line_4.length !== 0) {
-					line_4.val('');
-					triggerEvent('change', line_4[0]);
+				var line_4 = elements.search.closest('form').querySelector('#street_4');
+				if (line_4) {
+					line_4.value = '';
+					elements.line_4.dispatchEvent(new Event('change'));
 				}
 			},
 			transliterate: c2a_config.autocomplete.advanced.transliterate,
@@ -145,12 +155,20 @@ function cc_m2_c2a() {
 	}
 }
 
+function parents(el, selector) {
+  var parents = [];
+  while ((el = el.parentNode) && el !== document) {
+    if (!selector || el.matches(selector)) parents.push(el);
+  }
+  return parents;
+}
+
 // Postcode Lookup
 var cc_activate_flags = [];
 function activate_cc_m2_uk() {
 	if (c2a_config.postcodelookup.enabled) {
-		var cfg = {
-			id: '',
+		var active_cfg = {
+			id: 'm2_address',
 			core: {
 				key: c2a_config.main.key,
 				preformat: true,
@@ -161,7 +179,18 @@ function activate_cc_m2_uk() {
 					town: true
 				}
 			},
-			dom: {},
+			dom: {
+				company:	document.querySelector('[name="company"]'),
+				address_1:	document.getElementById('street_1'),
+				address_2:	document.getElementById('street_2'),
+				address_3:	document.getElementById('street_3'),
+				address_4:	document.getElementById('street_4'),
+				postcode:	document.querySelector('[name="postcode"]'),
+				town:		document.querySelector('[name="city"]'),
+				county:		document.querySelector('[name="region"]'),
+				county_list:document.querySelector('[name="region_id"]'),
+				country:	document.querySelector('[name="country_id"]')
+			},
 			sort_fields: {
 				active: true,
 				parent: '.field:not(.additional)'
@@ -172,102 +201,145 @@ function activate_cc_m2_uk() {
 			county_data: c2a_config.postcodelookup.advanced.county_data,
 			ui: {
 				onResultSelected: function(dataset, id, fields) {
-					if (cfg.county_data == 'former_postal') {
-						fields.county[0].value = dataset.postal_county;
-					} else if (cfg.county_data == 'traditional') {
-						fields.county[0].value = dataset.traditional_county;
+					if (active_cfg.county_data == 'former_postal') {
+						fields.county.value = dataset.postal_county;
+					} else if (active_cfg.county_data == 'traditional') {
+						fields.county.value = dataset.traditional_county;
 					} else {
-						fields.county[0].value = '';
+						fields.county.value = '';
 					}
 
-					fields.county.trigger('change');
-					fields.address_4.val('').change();
+					if (fields.county) fields.county.dispatchEvent(new Event('change'));
+					if (fields.address_4) {
+						fields.address_4.value = '';
+						fields.address_4.dispatchEvent(new Event('change'));
+					}
 
-					fields.postcode.closest('form').find('.cp_manual_entry').hide(200);
+					fields.postcode.closest('form').querySelector('.cp_manual_entry').style.display = 'none';
 				}
 			}
 		};
 
-		var address_dom = {
-			company:	jQuery('[name="company"]'),
-			address_1:	jQuery('#street_1'),
-			address_2:	jQuery('#street_2'),
-			address_3:	jQuery('#street_3'),
-			address_4:	jQuery('#street_4'),
-			postcode:	jQuery('[name="postcode"]'),
-			town:		jQuery('[name="city"]'),
-			county:		jQuery('[name="region"]'),
-			county_list:jQuery('[name="region_id"]'),
-			country:	jQuery('[name="country_id"]')
-		};
-
-		cfg.dom = address_dom;
-		cfg.id = 'm2_address';
-
-		if (cc_activate_flags.indexOf(cfg.id) == -1 && cfg.dom.postcode.length == 1) {
-			cc_activate_flags.push(cfg.id);
+		if (cc_activate_flags.indexOf(active_cfg.id) == -1 && active_cfg.dom.postcode) {
+			cc_activate_flags.push(active_cfg.id);
 
 			// modify the Layout
-			var postcode_elem = cfg.dom.postcode;
-			postcode_elem.wrap('<div class="search-bar"></div>');
+			var postcode_elem = active_cfg.dom.postcode;
+
+			var postcode_wrapper_elem = document.createElement('div');
+			postcode_wrapper_elem.classList.add('search-bar');
+			postcode_elem.replaceWith(postcode_wrapper_elem);
+			postcode_wrapper_elem.appendChild(postcode_elem);
 
 			// button has to go before input elem otherwise layout messed up when m2 validaton alert is displayed
-			postcode_elem.before('<button type="button" class="action primary">' +
-				'<span>' + cfg.txt.search_buttontext + '</span></button>');
+			var button_text_elem = document.createElement('span');
+			button_text_elem.textContent = active_cfg.txt.search_buttontext;
+
+			var button_elem = document.createElement('button');
+			button_elem.setAttribute('type', 'button'); // Required to prevent form from submitting
+			button_elem.classList.add('action', 'primary');
+			button_elem.appendChild(button_text_elem);
+			postcode_elem.before(button_elem);
 
 			// STANDARD
-			postcode_elem.closest('.search-bar').after('<div class="search-list" style="display: none;"><select></select></div>' +
-				'<div class="mage-error" generated><div class="search-subtext"></div></div>');
+			var error_elem = document.createElement('div');
+			error_elem.classList.add('search-subtext');
+
+			var error_wrapper_elem = document.createElement('div');
+			error_wrapper_elem.classList.add('mage-error');
+			error_wrapper_elem.setAttribute('generated', '');
+			error_wrapper_elem.appendChild(error_elem);
+			postcode_wrapper_elem.after(error_wrapper_elem);
+
+			var results_elem = document.createElement('select');
+
+			var results_wrapper_elem = document.createElement('div');
+			results_wrapper_elem.classList.add('search-list');
+			results_wrapper_elem.style.display = 'none';
+			results_wrapper_elem.appendChild(results_elem);
+			postcode_wrapper_elem.after(results_wrapper_elem);
 
 			/* m2 expects the alert elem to be directly after postcode 
 			input, so let's move it back there to prevent m2 using our 
 			button for displaying invalid postcode error text */
-			postcode_elem.after(postcode_elem.closest('.control').find('[role="alert"]'));
+			postcode_elem.after(postcode_elem.closest('.control').querySelector('[role="alert"]'));
 
 			// add/show manual entry text
-			if (cfg.hide_fields) {
-				if (jQuery('#' + cfg.id + '_cp_manual_entry').length === 0 && postcode_elem.val() === '') {
-					var svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 305.67 179.25">' +
-						'<rect x="-22.85" y="66.4" width="226.32" height="47.53" rx="17.33" ry="17.33" transform="translate(89.52 -37.99) rotate(45)"/>' +
-						'<rect x="103.58" y="66.4" width="226.32" height="47.53" rx="17.33" ry="17.33" transform="translate(433.06 0.12) rotate(135)"/>' +
-						'</svg>';
+			if (active_cfg.hide_fields) {
+				if (!document.getElementById(active_cfg.id + '_cp_manual_entry') && postcode_elem.value === '') {
+					var rect1_elem = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+					rect1_elem.setAttribute('x', '-22.85');
+					rect1_elem.setAttribute('y', '66.4');
+					rect1_elem.setAttribute('width', '226.32');
+					rect1_elem.setAttribute('height', '47.53');
+					rect1_elem.setAttribute('rx', '17.33');
+					rect1_elem.setAttribute('ry', '17.33');
+					rect1_elem.setAttribute('transform', 'translate(89.52 -37.99) rotate(45)');
 
-					tmp_manual_html = '<div class="field cp_manual_entry" id="' + cfg.id + '_cp_manual_entry" style="margin-top: 15px; margin-bottom: 15px;"><label>' + cfg.txt.manual_entry + '</label>' + svg + '</div>';
-					jQuery(postcode_elem).next('[role="alert"]').after(tmp_manual_html);
+					var rect2_elem = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+					rect2_elem.setAttribute('x', '103.58');
+					rect2_elem.setAttribute('y', '66.4');
+					rect2_elem.setAttribute('width', '226.32');
+					rect2_elem.setAttribute('height', '47.53');
+					rect2_elem.setAttribute('rx', '17.33');
+					rect2_elem.setAttribute('ry', '17.33');
+					rect2_elem.setAttribute('transform', 'translate(433.06 0.12) rotate(135)');
 
-					jQuery('#' + cfg.id + '_cp_manual_entry').on('click', function() {
-						jQuery(postcode_elem).closest('form').find('.crafty_address_field').removeClass('crafty_address_field_hidden');
-						jQuery('#' + cfg.id + '_cp_manual_entry').hide(200);
+					var svg_elem = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+					svg_elem.setAttribute('viewBox', '0 0 305.67 179.25');
+					svg_elem.setAttribute('style', 'display: inline-block; width: 1em;');
+					svg_elem.appendChild(rect1_elem);
+					svg_elem.appendChild(rect2_elem);
+
+					var manual_entry_label_elem = document.createElement('label');
+					manual_entry_label_elem.textContent = active_cfg.txt.manual_entry;
+					manual_entry_label_elem.style.cursor = 'pointer';
+
+					var manual_entry_wrapper_elem = document.createElement('div');
+					manual_entry_wrapper_elem.id = active_cfg.id + '_cp_manual_entry';
+					manual_entry_wrapper_elem.classList.add('field', 'cp_manual_entry');
+					manual_entry_wrapper_elem.style.margin = '15px 0 15px 0';
+					manual_entry_wrapper_elem.appendChild(manual_entry_label_elem);
+					manual_entry_wrapper_elem.appendChild(svg_elem);
+
+					postcode_elem.nextElementSibling.after(manual_entry_wrapper_elem);
+
+					document.getElementById(active_cfg.id + '_cp_manual_entry').addEventListener('click', () => {
+						postcode_elem.closest('form').querySelectorAll('.crafty_address_field').forEach((field) => {
+							field.classList.remove('crafty_address_field_hidden');
+						});
+						document.getElementById(active_cfg.id + '_cp_manual_entry').style.display = 'none';
 					});
 				}
 			}
 
-			var new_container = postcode_elem.closest(cfg.sort_fields.parent);
-			new_container.addClass('search-container').attr('id', cfg.id).addClass('type_3');
+			var new_container = postcode_elem.closest(active_cfg.sort_fields.parent);
+			new_container.id = active_cfg.id;
+			new_container.classList.add('search-container', 'type_3');
 
-			var cc_customer_address = new cc_ui_handler(cfg);
+			var cc_customer_address = new cc_ui_handler(active_cfg);
 
 			// respect the form's two-column layout
 			cc_customer_address.sort = function() {
 				var elems = this.cfg.dom;
-				var country = elems.country.parents(this.cfg.sort_fields.parent).last();
-				var line_1 = elems.address_1.parents(this.cfg.sort_fields.parent).last();
-				country.insertBefore(line_1);
+				var country = parents(elems.country, this.cfg.sort_fields.parent).at(-1);
+				var line_1 = parents(elems.address_1, this.cfg.sort_fields.parent).at(-1);
+				line_1.before(country);
 
 				var searchContainer = {};
-				searchContainer = this.search_object;
+				searchContainer = this.search_object[0];
 				country.after(searchContainer);
 
 				//IWD checkout - temporary ???
-				if (jQuery('.crafty-results-container').length > 0) {
-					searchContainer.after(searchContainer.closest('.fieldset').find('.crafty-results-container'));
+				if (document.querySelector('.crafty-results-container')) {
+					searchContainer.after(searchContainer.closest('.fieldset').querySelector('.crafty-results-container'));
 				}
 				
 				if (this.cfg.hide_fields) {
 					var tagElement = [];
 					tagElement = ['company', 'address_1', 'town', 'county', 'county_list'];
 					for (var i = 0; i < tagElement.length; i++) {
-						elems[tagElement[i]].parents(this.cfg.sort_fields.parent).last().addClass('crafty_address_field');
+						parents(elems[tagElement[i]], this.cfg.sort_fields.parent).at(-1).classList.add('crafty_address_field');
 					}
 				}
 			};
@@ -289,13 +361,13 @@ function cc_m2_phone() {
 	}
 
 	var add_phone = setInterval(function() {
-		var phone_element = jQuery('input[name="telephone"]');
-		if (phone_element.length == 1 && phone_element.data('cc') != '1') {
-			phone_element.data('cc', '1');
-			var country = phone_element.closest('form').find('select[name="country_id"]');
+		var phone_element = document.querySelector('input[name="telephone"]');
+		if (phone_element && phone_element.dataset.cc != '1') {
+			phone_element.dataset.cc = '1';
+			var country = phone_element.closest('form').querySelector('select[name="country_id"]');
 			window.cc_holder.addPhoneVerify({
-				phone: phone_element[0],
-				country: country[0]
+				phone: phone_element,
+				country: country
 			});
 			clearInterval(add_phone);
 		}
@@ -303,37 +375,31 @@ function cc_m2_phone() {
 }
 
 window.cc_holder = null;
-requirejs(['jquery'], function($) {
-	jQuery(document).ready(function() {
-		if (!c2a_config.main.enable_extension) { return; }
+function cc_init() {
+	if (!c2a_config.main.enable_extension) { return; }
 
-		if (c2a_config.main.enable_extension && c2a_config.main.key == null) {
-			console.warn('Fetchify: No access token configured.');
-			return;
-		}
-
-		if (c2a_config.autocomplete.enabled) {
-			setInterval(cc_m2_c2a, 200);
-		}
-
-		if (c2a_config.postcodelookup.enabled) {
-			setInterval(activate_cc_m2_uk, 200);
-		}
-
-		if (c2a_config.phonevalidation.enabled) {
-			setInterval(cc_m2_phone, 200);
-		}
-	});
-});
-
-// IE11 compatibility
-function triggerEvent(eventName, target) {
-	var event;
-	if (typeof (Event) === 'function') {
-		event = new Event(eventName);
-	} else {
-		event = document.createEvent('Event');
-		event.initEvent(eventName, true, true);
+	if (c2a_config.main.enable_extension && c2a_config.main.key == null) {
+		console.warn('Fetchify: No access token configured.');
+		return;
 	}
-	target.dispatchEvent(event);
+
+	if (c2a_config.autocomplete.enabled) {
+		setInterval(cc_m2_c2a, 200);
+	}
+
+	if (c2a_config.postcodelookup.enabled) {
+		setInterval(activate_cc_m2_uk, 200);
+	}
+
+	if (c2a_config.phonevalidation.enabled) {
+		setInterval(cc_m2_phone, 200);
+	}
 }
+
+requirejs(['jquery'], function($) {
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', cc_init);
+	} else {
+		cc_init();
+	}
+});

--- a/view/frontend/web/form_integrations/cc_customer_register.js
+++ b/view/frontend/web/form_integrations/cc_customer_register.js
@@ -1,41 +1,32 @@
 window.cc_holder = null;
 
-requirejs(['jquery'], function($) {
-	jQuery(document).ready(function() {
-		if (!c2a_config.main.enable_extension) { return; }
+function cc_init() {
+	if (!c2a_config.main.enable_extension) { return; }
 
-		if (c2a_config.emailvalidation.enabled && c2a_config.main.key != null) {
-			if (window.cc_holder == null) {
-				window.cc_holder = new clickToAddress({
-					accessToken: c2a_config.main.key,
-					tag: 'magento2'
+	if (c2a_config.emailvalidation.enabled && c2a_config.main.key != null) {
+		if (window.cc_holder == null) {
+			window.cc_holder = new clickToAddress({
+				accessToken: c2a_config.main.key,
+				tag: 'magento2'
+			});
+		}
+
+		setInterval(function() {
+			var email_element = document.getElementById('email_address');
+			if (email_element.dataset.cc != '1') {
+				email_element.dataset.cc = '1';
+				window.cc_holder.addEmailVerify({
+					email: email_element
 				});
 			}
-
-			setInterval(function() {
-				var email_elements = jQuery('input#email_address');
-				email_elements.each(function(index) {
-					var email_element = email_elements.eq(index);
-					if (email_element.data('cc') != '1') {
-						email_element.data('cc', '1');
-						window.cc_holder.addEmailVerify({
-							email: email_element[0]
-						});
-					}
-				});
-			}, 200);
-		}
-	});
-});
-
-// IE11 compatibility
-function triggerEvent(eventName, target) {
-	var event;
-	if (typeof (Event) === 'function') {
-		event = new Event(eventName);
-	} else {
-		event = document.createEvent('Event');
-		event.initEvent(eventName, true, true);
+		}, 200);
 	}
-	target.dispatchEvent(event);
 }
+
+requirejs(['jquery'], function($) {
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', cc_init);
+	} else {
+		cc_init();
+	}
+});

--- a/view/frontend/web/form_integrations/cc_default_checkout.js
+++ b/view/frontend/web/form_integrations/cc_default_checkout.js
@@ -4,82 +4,122 @@ function cc_m2_c2a() {
 	 * (needed on sites that load page elements
 	 * via multiple ajax requests)
 	 */
-	if (jQuery('[name="postcode"]').length == 0 || jQuery('[name="street[0]"]').length == 0) {
+	if (!document.querySelector('[name="postcode"]') || !document.querySelector('[name="street[0]"]')) {
 		return;
 	}
 
-	jQuery('[name="postcode"]').each(function(index, elem) {
-		if (jQuery(elem).data('cc_attach') != '1') {
-			jQuery(elem).data('cc_attach', '1');
+	document.querySelectorAll('[name="postcode"]').forEach((elem) => {
+		if (elem.dataset.cc_attach != '1') {
+			elem.dataset.cc_attach = '1';
 
-			var form = jQuery(elem).closest('form');
-			var custom_id = '';
-
-			if (c2a_config.autocomplete.advanced.search_elem_id !== null) {
-				custom_id = ' id="' + c2a_config.autocomplete.advanced.search_elem_id + '"';
-			}
+			var form = elem.closest('form');
 
 			// null fix for m2_1.1.16
 			if (c2a_config.autocomplete.texts.search_label == null) c2a_config.autocomplete.texts.search_label = '';
 
-			var tmp_html = '<div class="field"' + custom_id + '><label class="label" for="fetchify_search">' +
-				c2a_config.autocomplete.texts.search_label + '</label>' +
-				'<div class="control"><input class="cc_search_input" type="text" name="fetchify_search"/></div></div>';
+			var search_elem = document.createElement('input');
+			search_elem.classList.add('cc_search_input');
+			search_elem.name = 'fetchify_search';
+			search_elem.setAttribute('type', 'text');
+
+			var small_wrapper_elem = document.createElement('div');
+			small_wrapper_elem.classList.add('control');
+			small_wrapper_elem.appendChild(search_elem);
+
+			var label_elem = document.createElement('label');
+			label_elem.classList.add('label');
+			label_elem.setAttribute('for', 'fetchify_search');
+			label_elem.textContent = c2a_config.autocomplete.texts.search_label;
+
+			var big_wrapper_elem = document.createElement('div');
+			if (c2a_config.autocomplete.advanced.search_elem_id !== null) { big_wrapper_elem.id = c2a_config.autocomplete.advanced.search_elem_id; } // custom id
+			big_wrapper_elem.classList.add('field');
+			big_wrapper_elem.appendChild(label_elem);
+			big_wrapper_elem.appendChild(small_wrapper_elem);
 
 			if (c2a_config.autocomplete.advanced.hide_fields) {
-				var svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 305.67 179.25">' +
-					'<rect x="-22.85" y="66.4" width="226.32" height="47.53" rx="17.33" ry="17.33" transform="translate(89.52 -37.99) rotate(45)"/>' +
-					'<rect x="103.58" y="66.4" width="226.32" height="47.53" rx="17.33" ry="17.33" transform="translate(433.06 0.12) rotate(135)"/>' +
-					'</svg>';
+				var rect1_elem = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+				rect1_elem.setAttribute('x', '-22.85');
+				rect1_elem.setAttribute('y', '66.4');
+				rect1_elem.setAttribute('width', '226.32');
+				rect1_elem.setAttribute('height', '47.53');
+				rect1_elem.setAttribute('rx', '17.33');
+				rect1_elem.setAttribute('ry', '17.33');
+				rect1_elem.setAttribute('transform', 'translate(89.52 -37.99) rotate(45)');
 
-				tmp_html += '<div class="field cc_hide_fields_action"><label>' + c2a_config.autocomplete.texts.manual_entry_toggle + '</label>' + svg + '</div>';
+				var rect2_elem = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+				rect2_elem.setAttribute('x', '103.58');
+				rect2_elem.setAttribute('y', '66.4');
+				rect2_elem.setAttribute('width', '226.32');
+				rect2_elem.setAttribute('height', '47.53');
+				rect2_elem.setAttribute('rx', '17.33');
+				rect2_elem.setAttribute('ry', '17.33');
+				rect2_elem.setAttribute('transform', 'translate(433.06 0.12) rotate(135)');
+
+				var svg_elem = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+				svg_elem.setAttribute('viewBox', '0 0 305.67 179.25');
+				svg_elem.appendChild(rect1_elem);
+				svg_elem.appendChild(rect2_elem);
+
+				var manual_entry_label_elem = document.createElement('label');
+				manual_entry_label_elem.innerText = c2a_config.autocomplete.texts.manual_entry_toggle;
+				manual_entry_label_elem.style.cursor = 'pointer';
+
+				var manual_entry_wrapper_elem = document.createElement('div');
+				manual_entry_wrapper_elem.classList.add('field', 'cc_hide_fields_action');
+				manual_entry_wrapper_elem.appendChild(manual_entry_label_elem);
+				manual_entry_wrapper_elem.appendChild(svg_elem);
+
+				form.querySelector('[name="street[0]"]').closest('fieldset').after(manual_entry_wrapper_elem);
 			}
 
 			if (!c2a_config.autocomplete.advanced.use_first_line || c2a_config.autocomplete.advanced.hide_fields) {
-				form.find('[name="street[0]"]').closest('fieldset').before(tmp_html);
+				form.querySelector('[name="street[0]"]').closest('fieldset').before(big_wrapper_elem);
 			} else {
-				form.find('[name="street[0]"]').addClass('cc_search_input');
+				form.querySelector('[name="street[0]"]').classList.add('cc_search_input');
 			}
 
 			if (c2a_config.autocomplete.advanced.lock_country_to_dropdown) {
 				if (c2a_config.autocomplete.advanced.use_first_line) {
-					form.find('.cc_search_input').closest('fieldset').before(form.find('[name="country_id"]').closest('div.field'));
+					form.querySelector('.cc_search_input').closest('fieldset').before(form.querySelector('[name="country_id"]').closest('div.field'));
 				} else {
-					form.find('.cc_search_input').closest('div.field').before(form.find('[name="country_id"]').closest('div.field'));
+					form.querySelector('.cc_search_input').closest('div.field').before(form.querySelector('[name="country_id"]').closest('div.field'));
 				}
 			}
 
 			var dom = {
-				search:		form.find('.cc_search_input'),
-				company:	form.find('[name="company"]'),
-				line_1:		form.find('[name="street[0]"]'),
-				line_2:		form.find('[name="street[1]"]'),
-				postcode:	form.find('[name="postcode"]'),
-				town:		form.find('[name="city"]'),
+				search:		form.querySelector('.cc_search_input'),
+				company:	form.querySelector('[name="company"]'),
+				line_1:		form.querySelector('[name="street[0]"]'),
+				line_2:		form.querySelector('[name="street[1]"]'),
+				postcode:	form.querySelector('[name="postcode"]'),
+				town:		form.querySelector('[name="city"]'),
 				county:		{
-					input:	form.find('[name="region"]'),
-					list:	form.find('[name="region_id"]')
+					input:	form.querySelector('[name="region"]'),
+					list:	form.querySelector('[name="region_id"]')
 				},
-				country:	form.find('[name="country_id"]')
+				country:	form.querySelector('[name="country_id"]')
 			};
 
 			window.cc_holder.attach({
-				search:		dom.search[0],
-				company:	dom.company[0],
-				line_1:		dom.line_1[0],
-				line_2:		dom.line_2[0],
-				postcode:	dom.postcode[0],
-				town:		dom.town[0],
+				search:		dom.search,
+				company:	dom.company,
+				line_1:		dom.line_1,
+				line_2:		dom.line_2,
+				postcode:	dom.postcode,
+				town:		dom.town,
 				county:		{
 					input:	dom.county.input,
 					list:	dom.county.list
 				},
-				country:	dom.country[0]
+				country:	dom.country
 			});
 			
-			form.find('.cc_hide_fields_action').on('click', function() {
-				cc_hide_fields(dom, 'manual-show');
-			});
+			if (c2a_config.autocomplete.advanced.hide_fields) {
+				form.querySelector('.cc_hide_fields_action').addEventListener('click', () => {
+					cc_hide_fields(dom, 'manual-show');
+				});
+			}
 
 			cc_hide_fields(dom, 'init');
 		}
@@ -89,35 +129,6 @@ function cc_m2_c2a() {
 // Postcode Lookup
 function activate_cc_m2_uk() {
 	if (c2a_config.postcodelookup.enabled) {
-		var cfg = {
-			id: '',
-			core: {
-				key: c2a_config.main.key,
-				preformat: true,
-				capsformat: {
-					address: true,
-					organization: true,
-					county: true,
-					town: true
-				}
-			},
-			dom: {},
-			sort_fields: {
-				active: true,
-				parent: '.field:not(.additional)'
-			},
-			hide_fields: c2a_config.postcodelookup.hide_fields,
-			txt: c2a_config.postcodelookup.txt,
-			error_msg: c2a_config.postcodelookup.error_msg,
-			county_data: c2a_config.postcodelookup.advanced.county_data,
-			ui: {
-				onResultSelected: function(dataset, id, fields) {
-					fields.postcode.closest('form').find('.cp_manual_entry').hide(200);
-					fields.address_4.val('').change();
-				}
-			}
-		};
-
 		var dom = {
 			company:	'[name="company"]',
 			address_1:	'[name="street[0]"]',
@@ -131,8 +142,7 @@ function activate_cc_m2_uk() {
 			country:	'[name="country_id"]'
 		};
 
-		var postcode_elements = jQuery(dom.postcode);
-		postcode_elements.each(function(index) {
+		document.querySelectorAll(dom.postcode).forEach((postcode_elem) => {
 			/**
 			 * The Magento 2 checkout loads fields
 			 * asynchronously so we need to check 
@@ -141,62 +151,145 @@ function activate_cc_m2_uk() {
 			 * a race condition scenario on slow 
 			 * devices/connections.
 			 */
-			var form = postcode_elements.eq(index).closest('form');
+			var form = postcode_elem.closest('form');
 			if (
-				postcode_elements.eq(index).attr('cc_pcl_applied') != '1'
-				&& form.find(dom.address_1).length === 1
-				&& form.find(dom.country).length === 1
+				postcode_elem.dataset.cc_pcl_applied != '1'
+				&& form.querySelector(dom.address_1)
+				&& form.querySelector(dom.country)
 			) {
-				var active_cfg = {};
-				jQuery.extend(active_cfg, cfg);
-				active_cfg.id = 'm2_' + cc_index;
-				cc_index++;
-
-				active_cfg.dom = {
-					company:		form.find(dom.company),
-					address_1:		form.find(dom.address_1),
-					address_2:		form.find(dom.address_2),
-					address_3:		form.find(dom.address_3),
-					address_4:		form.find(dom.address_4),
-					postcode:		postcode_elements.eq(index),
-					town:			form.find(dom.town),
-					county:			form.find(dom.county),
-					county_list:	form.find(dom.county_list),
-					country:		form.find(dom.country)
+				var active_cfg = {
+					id: 'm2_' + cc_index,
+					core: {
+						key: c2a_config.main.key,
+						preformat: true,
+						capsformat: {
+							address: true,
+							organization: true,
+							county: true,
+							town: true
+						}
+					},
+					dom: {
+						company:		form.querySelector(dom.company),
+						address_1:		form.querySelector(dom.address_1),
+						address_2:		form.querySelector(dom.address_2),
+						address_3:		form.querySelector(dom.address_3),
+						address_4:		form.querySelector(dom.address_4),
+						postcode:		postcode_elem,
+						town:			form.querySelector(dom.town),
+						county:			form.querySelector(dom.county),
+						county_list:	form.querySelector(dom.county_list),
+						country:		form.querySelector(dom.country)
+					},
+					sort_fields: {
+						active: true,
+						parent: '.field:not(.additional)'
+					},
+					hide_fields: c2a_config.postcodelookup.hide_fields,
+					txt: c2a_config.postcodelookup.txt,
+					error_msg: c2a_config.postcodelookup.error_msg,
+					county_data: c2a_config.postcodelookup.advanced.county_data,
+					ui: {
+						onResultSelected: function(dataset, id, fields) {
+							fields.postcode.closest('form').querySelector('.cp_manual_entry').style.display = 'none';
+							if (fields.address_4) {
+								fields.address_4.value = '';
+								fields.address_4.dispatchEvent(new Event('change'));
+							}
+						}
+					}
 				};
 
+				cc_index++;
+
 				// modify the Layout
-				var postcode_elem = active_cfg.dom.postcode;
-				postcode_elem.wrap('<div class="search-bar"></div>');
-				postcode_elem.after('<button type="button" class="action primary">' +
-					'<span>' + active_cfg.txt.search_buttontext + '</span></button>');
+				var postcode_wrapper_elem = document.createElement('div');
+				postcode_wrapper_elem.classList.add('search-bar');
+				postcode_elem.replaceWith(postcode_wrapper_elem);
+				postcode_wrapper_elem.appendChild(postcode_elem);
 
 				// STANDARD
-				postcode_elem.closest('.search-bar').after('<div class="search-list" style="display: none;"><select></select></div>' +
-					'<div class="mage-error" generated><div class="search-subtext"></div></div>');
+				var button_text_elem = document.createElement('span');
+				button_text_elem.textContent = active_cfg.txt.search_buttontext;
+
+				var button_elem = document.createElement('button');
+				button_elem.setAttribute('type', 'button'); // Required to prevent form from submitting
+				button_elem.classList.add('action', 'primary');
+				button_elem.appendChild(button_text_elem);
+				postcode_wrapper_elem.appendChild(button_elem);
+
+				var error_elem = document.createElement('div');
+				error_elem.classList.add('search-subtext');
+
+				var error_wrapper_elem = document.createElement('div');
+				error_wrapper_elem.classList.add('mage-error');
+				error_wrapper_elem.setAttribute('generated', '');
+				error_wrapper_elem.appendChild(error_elem);
+				postcode_wrapper_elem.after(error_wrapper_elem);
+
+				var results_elem = document.createElement('select');
+
+				var results_wrapper_elem = document.createElement('div');
+				results_wrapper_elem.classList.add('search-list');
+				results_wrapper_elem.style.display = 'none';
+				results_wrapper_elem.appendChild(results_elem);
+				postcode_wrapper_elem.after(results_wrapper_elem);
 
 				// input after postcode
 				var new_container = postcode_elem.closest(active_cfg.sort_fields.parent);
-				new_container.addClass('search-container').attr('id', active_cfg.id).addClass('type_3');
+				new_container.id = active_cfg.id;
+				new_container.classList.add('search-container', 'type_3');
 
 				// add/show manual entry text
 				if (active_cfg.hide_fields) {
-					if (jQuery('#' + active_cfg.id + '_cp_manual_entry').length === 0 && postcode_elem.val() === '') {
-						var svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 305.67 179.25">' +
-							'<rect x="-22.85" y="66.4" width="226.32" height="47.53" rx="17.33" ry="17.33" transform="translate(89.52 -37.99) rotate(45)"/>' +
-							'<rect x="103.58" y="66.4" width="226.32" height="47.53" rx="17.33" ry="17.33" transform="translate(433.06 0.12) rotate(135)"/>' +
-							'</svg>';
-						tmp_manual_html = '<div class="field cp_manual_entry" id="' + active_cfg.id + '_cp_manual_entry" style="margin-top: 15px; margin-bottom: 15px;"><label>' + active_cfg.txt.manual_entry + '</label>' + svg + '</div>';
-						jQuery(postcode_elem).closest('.field').find('button').after(tmp_manual_html);
+					if (!document.getElementById(active_cfg.id + '_cp_manual_entry') && postcode_elem.value === '') {
+						var rect1_elem = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+						rect1_elem.setAttribute('x', '-22.85');
+						rect1_elem.setAttribute('y', '66.4');
+						rect1_elem.setAttribute('width', '226.32');
+						rect1_elem.setAttribute('height', '47.53');
+						rect1_elem.setAttribute('rx', '17.33');
+						rect1_elem.setAttribute('ry', '17.33');
+						rect1_elem.setAttribute('transform', 'translate(89.52 -37.99) rotate(45)');
 
-						jQuery('#' + active_cfg.id + '_cp_manual_entry').on('click', function() {
-							jQuery(form).find('.crafty_address_field').removeClass('crafty_address_field_hidden');
-							jQuery('#' + active_cfg.id + '_cp_manual_entry').hide(200);
+						var rect2_elem = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+						rect2_elem.setAttribute('x', '103.58');
+						rect2_elem.setAttribute('y', '66.4');
+						rect2_elem.setAttribute('width', '226.32');
+						rect2_elem.setAttribute('height', '47.53');
+						rect2_elem.setAttribute('rx', '17.33');
+						rect2_elem.setAttribute('ry', '17.33');
+						rect2_elem.setAttribute('transform', 'translate(433.06 0.12) rotate(135)');
+
+						var svg_elem = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+						svg_elem.setAttribute('viewBox', '0 0 305.67 179.25');
+						svg_elem.setAttribute('style', 'display: inline-block; width: 1em;');
+						svg_elem.appendChild(rect1_elem);
+						svg_elem.appendChild(rect2_elem);
+
+						var manual_entry_label_elem = document.createElement('label');
+						manual_entry_label_elem.textContent = active_cfg.txt.manual_entry;
+						manual_entry_label_elem.style.cursor = 'pointer';
+
+						var manual_entry_wrapper_elem = document.createElement('div');
+						manual_entry_wrapper_elem.id = active_cfg.id + '_cp_manual_entry';
+						manual_entry_wrapper_elem.classList.add('field', 'cp_manual_entry');
+						manual_entry_wrapper_elem.style.margin = '15px 0 15px 0';
+						manual_entry_wrapper_elem.appendChild(manual_entry_label_elem);
+						manual_entry_wrapper_elem.appendChild(svg_elem);
+
+						postcode_elem.closest('.field').querySelector('button').after(manual_entry_wrapper_elem);
+
+						document.getElementById(active_cfg.id + '_cp_manual_entry').addEventListener('click', () => {
+							form.querySelectorAll('.crafty_address_field').forEach((field) => {
+								field.classList.remove('crafty_address_field_hidden');
+							});
+							document.getElementById(active_cfg.id + '_cp_manual_entry').style.display = 'none';
 						});
 					}
 				}
 
-				active_cfg.dom.postcode.attr('cc_pcl_applied', '1');
+				postcode_elem.dataset.cc_pcl_applied = '1';
 				var cc_generic = new cc_ui_handler(active_cfg);
 				cc_generic.activate();
 			}
@@ -219,7 +312,7 @@ function cc_hide_fields(dom, action) {
 			var formEmpty = true;
 			var elementsToHide = ['line_1', 'line_2', 'line_3', 'line_4', 'town', 'postcode', 'county'];
 			for (var i = 0; i < elementsToHide.length - 1; i++) { // -1 is to skip County
-				if (jQuery(dom[elementsToHide[i]]).length && jQuery(dom[elementsToHide[i]]).val() !== '') {
+				if (dom[elementsToHide[i]] && dom[elementsToHide[i]].value !== '') {
 					formEmpty = false;
 				}
 			}
@@ -229,24 +322,24 @@ function cc_hide_fields(dom, action) {
 			}
 
 			for (var i = 0; i < elementsToHide.length; i++) {
-				if (jQuery(dom[elementsToHide[i]]).length) {
+				if (dom[elementsToHide[i]]) {
 					switch (elementsToHide[i]) {
 						case 'county':
-							jQuery(dom[elementsToHide[i]].input).closest('.field').addClass('cc_hide');
-							jQuery(dom[elementsToHide[i]].list).closest('.field').addClass('cc_hide');
+							dom[elementsToHide[i]].input.closest('.field').classList.add('cc_hide');
+							dom[elementsToHide[i]].list.closest('.field').classList.add('cc_hide');
 							break;
 						case 'line_1':
-							jQuery(dom[elementsToHide[i]]).closest('fieldset.field').addClass('cc_hide');
+							dom[elementsToHide[i]].closest('fieldset.field').classList.add('cc_hide');
 							break;
 						default:
-							jQuery(dom[elementsToHide[i]]).closest('.field').addClass('cc_hide');
+							dom[elementsToHide[i]].closest('.field').classList.add('cc_hide');
 					}
 				}
 			}
 
 			// store the checking loop in the DOM object
-			var form = jQuery(dom.country).closest('form');
-			form.data('cc_hidden', 0);
+			var form = dom.country.closest('form');
+			form.dataset.cc_hidden = 0;
 
 			if (formEmpty) {
 				cc_hide_fields(dom, 'hide');
@@ -257,31 +350,31 @@ function cc_hide_fields(dom, action) {
 			setInterval(function() { cc_reveal_fields_on_error(dom); }, 250);
 			break;
 		case 'hide':
-			var form = jQuery(dom.country).closest('form');
-			form.find('.cc_hide').each(function(index, item) {
-				jQuery(item).addClass('cc_hidden');
+			var form = dom.country.closest('form');
+			form.querySelectorAll('.cc_hide').forEach(function(item) {
+				item.classList.add('cc_hidden');
 			});
-			form.find('.cc_hide_fields_action').removeClass('cc_slider_on');
-			form.data('cc_hidden', 1);
+			form.querySelector('.cc_hide_fields_action').classList.remove('cc_slider_on');
+			form.dataset.cc_hidden = 1;
 			break;
 		case 'manual-show':
 		case 'show':
-			jQuery(dom.country).trigger('change');
+			dom.country.dispatchEvent(new Event('change'));
 
-			var form = jQuery(dom.country).closest('form');
-			form.find('.cc_hide').each(function(index, item) {
-				jQuery(item).removeClass('cc_hidden');
+			var form = dom.country.closest('form');
+			form.querySelectorAll('.cc_hide').forEach(function(item) {
+				item.classList.remove('cc_hidden');
 			});
-			form.find('.cc_hide_fields_action').hide(200);
-			form.data('cc_hidden', 0);
+			form.querySelector('.cc_hide_fields_action').style.display = 'none';
+			form.dataset.cc_hidden = 0;
 
 			if (action == 'manual-show') {
-				jQuery(dom.country).trigger('change');
+				dom.country.dispatchEvent(new Event('change'));
 			}
 			break;
 		case 'toggle':
-			var form = jQuery(dom.country).closest('form');
-			if (form.data('cc_hidden') == 1) {
+			var form = dom.country.closest('form');
+			if (form.dataset.cc_hidden == 1) {
 				cc_hide_fields(dom, 'show');
 			} else {
 				cc_hide_fields(dom, 'hide');
@@ -291,191 +384,181 @@ function cc_hide_fields(dom, action) {
 }
 
 function cc_reveal_fields_on_error(dom) {
-	var form = jQuery(dom.country).closest('form');
+	var form = dom.country.closest('form');
 	var errors_present = false;
-	form.find('.cc_hide').each(function(index, item) {
-		if (jQuery(item).hasClass('_error')) {
+	form.querySelectorAll('.cc_hide').forEach(function(item) {
+		if (item.classList.contains('_error')) {
 			errors_present = true;
 		}
 	});
 
 	if (errors_present) {
 		cc_hide_fields(dom, 'show');
-		form.find('.cc_hide_fields_action').hide(); // prevent the user from hiding the fields again
+		form.querySelector('.cc_hide_fields_action').style.display = 'none'; // prevent the user from hiding the fields again
 	}
 }
-requirejs(['jquery'], function($) {
-	jQuery(document).ready(function() {
-		if (!c2a_config.main.enable_extension) { return; }
 
-		if (c2a_config.autocomplete.enabled && c2a_config.main.key != null) {
-			var config = {
-				accessToken: c2a_config.main.key,
-				onSetCounty: function(c2a, elements, county) {
-					return;
-				},
-				domMode: 'object',
-				gfxMode: c2a_config.autocomplete.gfx_mode,
-				style: {
-					ambient: c2a_config.autocomplete.gfx_ambient,
-					accent: c2a_config.autocomplete.gfx_accent
-				},
-				showLogo: false,
-				texts: c2a_config.autocomplete.texts,
-				onResultSelected: function(c2a, elements, address) {
-					var postcode = address.postal_code.substring(0, 2);
-					
-					switch (postcode) {
-						case 'JE':
-						case 'GG':
-						case 'IM':
-							jQuery(elements.country).val(postcode);
-							break;
-						default:
-							jQuery(elements.country).val(address.country.iso_3166_1_alpha_2);
-					}
+function cc_init() {
+	if (!c2a_config.main.enable_extension) { return; }
 
-					if (typeof elements.country != 'undefined') { triggerEvent('change', elements.country); }
+	if (c2a_config.autocomplete.enabled && c2a_config.main.key != null) {
+		var config = {
+			accessToken: c2a_config.main.key,
+			onSetCounty: function(c2a, elements, county) {
+				return;
+			},
+			domMode: 'object',
+			gfxMode: c2a_config.autocomplete.gfx_mode,
+			style: {
+				ambient: c2a_config.autocomplete.gfx_ambient,
+				accent: c2a_config.autocomplete.gfx_accent
+			},
+			showLogo: false,
+			texts: c2a_config.autocomplete.texts,
+			onResultSelected: function(c2a, elements, address) {
+				var postcode = address.postal_code.substring(0, 2);
+				
+				switch (postcode) {
+					case 'JE':
+					case 'GG':
+					case 'IM':
+						elements.country.value = postcode;
+						break;
+					default:
+						elements.country.value = address.country.iso_3166_1_alpha_2;
+				}
 
-					var county;
-					if (c2a.activeCountry === 'gbr' && !c2a_config.autocomplete.advanced.fill_uk_counties) {
-						county = { code: '', name: '', preferred: '' };
-					} else {
-						county = {
-							preferred: address.province,
-							code: address.province_code,
-							name: address.province_name
-						};
-					}
+				if (typeof elements.country != 'undefined') { elements.country.dispatchEvent(new Event('change')); }
 
-					if (elements.county.list.length == 1) {
-						c2a.setCounty(elements.county.list[0], county);
-					}
+				var county;
+				if (c2a.activeCountry === 'gbr' && !c2a_config.autocomplete.advanced.fill_uk_counties) {
+					county = { code: '', name: '', preferred: '' };
+				} else {
+					county = {
+						preferred: address.province,
+						code: address.province_code,
+						name: address.province_name
+					};
+				}
 
-					if (elements.county.input.length == 1) {
-						c2a.setCounty(elements.county.input[0], county);
-					}
+				if (elements.county.list) {
+					c2a.setCounty(elements.county.list, county);
+				}
 
-					if (typeof elements.county.input[0] != 'undefined') { triggerEvent('change', elements.county.input[0]); }
-					if (typeof elements.county.list[0] != 'undefined') { triggerEvent('change', elements.county.list[0]); }
-					if (typeof elements.company != 'undefined') { triggerEvent('change', elements.company); }
-					if (typeof elements.line_1 != 'undefined') { triggerEvent('change', elements.line_1); }
-					if (typeof elements.line_2 != 'undefined') { triggerEvent('change', elements.line_2); }
-					if (typeof elements.postcode != 'undefined') { triggerEvent('change', elements.postcode); }
-					if (typeof elements.town != 'undefined') { triggerEvent('change', elements.town); }
+				if (elements.county.input) {
+					c2a.setCounty(elements.county.input, county);
+				}
 
-					cc_hide_fields(elements, 'show');
+				if (elements.county.input) elements.county.input.dispatchEvent(new Event('change'));
+				if (elements.county.list) elements.county.list.dispatchEvent(new Event('change'));
+				if (elements.company) elements.company.dispatchEvent(new Event('change'));
+				if (elements.line_1) elements.line_1.dispatchEvent(new Event('change'));
+				if (elements.line_2) elements.line_2.dispatchEvent(new Event('change'));
+				if (elements.postcode) elements.postcode.dispatchEvent(new Event('change'));
+				if (elements.town) elements.town.dispatchEvent(new Event('change'));
 
-					
-					var line_3 = jQuery(elements.search).closest('form').find('[name="street[2]"]');
-					if (line_3.length !== 0) {
-						line_3.val('');
-						triggerEvent('change', line_3[0]);
-					}
-					
-					var line_4 = jQuery(elements.search).closest('form').find('[name="street[3]"]');
-					if (line_4.length !== 0) {
-						line_4.val('');
-						triggerEvent('change', line_4[0]);
-					}
-				},
-				onError: function() {
-					if (typeof this.activeDom.postcode !== 'undefined') {
-						cc_hide_fields(this.activeDom, 'show');
-					} else {
-						c2a_config.autocomplete.advanced.hide_fields = false;
-					}
-				},
-				transliterate: c2a_config.autocomplete.advanced.transliterate,
-				excludeAreas: c2a_config.autocomplete.exclusions.areas,
-				excludePoBox: c2a_config.autocomplete.exclusions.po_box,
-				debug: c2a_config.autocomplete.advanced.debug,
-				cssPath: false,
-				tag: 'magento2'
+				cc_hide_fields(elements, 'show');
+				
+				var line_3 = elements.search.closest('form').querySelector('[name="street[2]"]');
+				if (line_3) {
+					line_3.value = '';
+					line_3.dispatchEvent(new Event('change'));
+				}
+
+				var line_4 = elements.search.closest('form').querySelector('[name="street[3]"]');
+				if (line_4) {
+					line_4.value = '';
+					line_4.dispatchEvent(new Event('change'));
+				}
+			},
+			onError: function() {
+				if (typeof this.activeDom.postcode !== 'undefined') {
+					cc_hide_fields(this.activeDom, 'show');
+				} else {
+					c2a_config.autocomplete.advanced.hide_fields = false;
+				}
+			},
+			transliterate: c2a_config.autocomplete.advanced.transliterate,
+			excludeAreas: c2a_config.autocomplete.exclusions.areas,
+			excludePoBox: c2a_config.autocomplete.exclusions.po_box,
+			debug: c2a_config.autocomplete.advanced.debug,
+			cssPath: false,
+			tag: 'magento2'
+		};
+
+		if (typeof c2a_config.autocomplete.enabled_countries !== 'undefined') {
+			config.countryMatchWith = 'iso_2';
+			config.enabledCountries = c2a_config.autocomplete.enabled_countries;
+		}
+
+		if (c2a_config.autocomplete.advanced.lock_country_to_dropdown) {
+			config.countrySelector = false;
+			config.onSearchFocus = function(c2a, dom) {
+				var currentCountry = dom.country.options[dom.country.selectedIndex].value;
+				if (currentCountry !== '') {
+					var countryCode = getCountryCode(c2a, currentCountry, 'iso_2');
+					c2a.selectCountry(countryCode);
+				}
 			};
-
-			if (typeof c2a_config.autocomplete.enabled_countries !== 'undefined') {
-				config.countryMatchWith = 'iso_2';
-				config.enabledCountries = c2a_config.autocomplete.enabled_countries;
-			}
-
-			if (c2a_config.autocomplete.advanced.lock_country_to_dropdown) {
-				config.countrySelector = false;
-				config.onSearchFocus = function(c2a, dom) {
-					var currentCountry = dom.country.options[dom.country.selectedIndex].value;
-					if (currentCountry !== '') {
-						var countryCode = getCountryCode(c2a, currentCountry, 'iso_2');
-						c2a.selectCountry(countryCode);
-					}
-				};
-			}
-
-			window.cc_holder = new clickToAddress(config);
-			setInterval(cc_m2_c2a, 200);
 		}
 
-		if (c2a_config.autocomplete.enabled && c2a_config.main.key == null) {
-			console.warn('ClickToAddress: Incorrect token format supplied');
-		}
-
-		if (c2a_config.postcodelookup.enabled) {
-			setInterval(activate_cc_m2_uk, 200);
-		}
-
-		if (c2a_config.emailvalidation.enabled && c2a_config.main.key != null) {
-			if (window.cc_holder == null) {
-				window.cc_holder = new clickToAddress({
-					accessToken: c2a_config.main.key,
-				});
-			}
-
-			setInterval(function() {
-				var email_elements = jQuery('input#customer-email');
-				email_elements.each(function(index) {
-					var email_element = email_elements.eq(index);
-					if (email_element.data('cc') != '1') {
-						email_element.data('cc', '1');
-						window.cc_holder.addEmailVerify({
-							email: email_element[0]
-						});
-					}
-				});
-			}, 200);
-		}
-
-		if (c2a_config.phonevalidation.enabled && c2a_config.main.key != null) {
-			if (window.cc_holder == null) {
-				window.cc_holder = new clickToAddress({
-					accessToken: c2a_config.main.key,
-				});
-			}
-			
-			setInterval(function() {
-				var phone_elements = jQuery('input[name="telephone"]');
-				phone_elements.each(function(index) {
-					var phone_element = phone_elements.eq(index);
-					if (phone_element.data('cc') != '1') {
-						phone_element.data('cc', '1');
-						var country = phone_element.closest('form').find('select[name="country_id"]');
-						window.cc_holder.addPhoneVerify({
-							phone: phone_element[0],
-							country: country[0]
-						});
-					}
-				});
-			}, 200);
-		}
-	});
-});
-
-// IE11 compatibility
-function triggerEvent(eventName, target) {
-	var event;
-	if (typeof (Event) === 'function') {
-		event = new Event(eventName);
-	} else {
-		event = document.createEvent('Event');
-		event.initEvent(eventName, true, true);
+		window.cc_holder = new clickToAddress(config);
+		setInterval(cc_m2_c2a, 200);
 	}
-	target.dispatchEvent(event);
+
+	if (c2a_config.autocomplete.enabled && c2a_config.main.key == null) {
+		console.warn('ClickToAddress: Incorrect token format supplied');
+	}
+
+	if (c2a_config.postcodelookup.enabled) {
+		setInterval(activate_cc_m2_uk, 200);
+	}
+
+	if (c2a_config.emailvalidation.enabled && c2a_config.main.key != null) {
+		if (window.cc_holder == null) {
+			window.cc_holder = new clickToAddress({
+				accessToken: c2a_config.main.key,
+			});
+		}
+
+		setInterval(function() {
+			document.querySelectorAll('input#customer-email').forEach(function(email_element) {
+				if (email_element.dataset.cc != '1') {
+					email_element.dataset.cc = '1';
+					window.cc_holder.addEmailVerify({
+						email: email_element
+					});
+				}
+			});
+		}, 200);
+	}
+
+	if (c2a_config.phonevalidation.enabled && c2a_config.main.key != null) {
+		if (window.cc_holder == null) {
+			window.cc_holder = new clickToAddress({
+				accessToken: c2a_config.main.key,
+			});
+		}
+		
+		setInterval(function() {
+			document.querySelectorAll('input[name="telephone"]').forEach(function(phone_element) {
+				if (phone_element.dataset.cc != '1') {
+					phone_element.dataset.cc = '1';
+					var country = phone_element.closest('form').querySelector('select[name="country_id"]');
+					window.cc_holder.addPhoneVerify({
+						phone: phone_element,
+						country: country
+					});
+				}
+			});
+		}, 200);
+	}
 }
+
+requirejs(['jquery'], function($) {
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', cc_init);
+	} else {
+		cc_init();
+	}
+});

--- a/view/frontend/web/form_integrations/cc_hyva_checkout.js
+++ b/view/frontend/web/form_integrations/cc_hyva_checkout.js
@@ -11,7 +11,7 @@ function cc_m2_c2a() {
     return;
   }
 
-  document.querySelectorAll('[name="postcode"]').forEach((elem, index) => {
+  document.querySelectorAll('[name="postcode"]').forEach((elem) => {
     if (elem.dataset.cc_attach != '1') {
       elem.dataset.cc_attach = '1';
 
@@ -32,7 +32,7 @@ function cc_m2_c2a() {
 
       const wrapper1 = document.createElement('div');
       wrapper1.classList.add('flex', 'items-center', 'gap-4');
-      wrapper1.append(input);
+      wrapper1.appendChild(input);
 
       const label = document.createElement('label');
       label.classList.add('label');
@@ -41,12 +41,12 @@ function cc_m2_c2a() {
 
       const wrapper2 = document.createElement('div');
       wrapper2.classList.add('w-full', 'font-medium', 'text-gray-700', 'relative');
-      wrapper2.append(label);
-      wrapper2.append(wrapper1);
+      wrapper2.appendChild(label);
+      wrapper2.appendChild(wrapper1);
 
       const wrapper3 = document.createElement('div');
       wrapper3.classList.add('col-span-12', 'group', 'field-wrapper', 'field-type-text', 'field', 'field-reserved', 'md:col-span-12');
-      wrapper3.append(wrapper2);
+      wrapper3.appendChild(wrapper2);
 
       if (c2a_config.autocomplete.advanced.hide_fields) {
         const rect1 = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
@@ -70,17 +70,17 @@ function cc_m2_c2a() {
         const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
         svg.setAttribute('viewBox', '0 0 305.67 179.25');
         svg.setAttribute('style', 'display: inline-block; width: 1em;');
-        svg.append(rect1);
-        svg.append(rect2);
+        svg.appendChild(rect1);
+        svg.appendChild(rect2);
 
         const button = document.createElement('span');
         button.innerText = c2a_config.autocomplete.texts.manual_entry_toggle;
         button.style.cursor = 'pointer';
-        button.append(svg);
+        button.appendChild(svg);
 
         const button_wrapper = document.createElement('div');
         button_wrapper.classList.add('col-span-12', 'group', 'field-wrapper', 'field-type-text', 'field', 'field-reserved', 'md:col-span-12', 'cc_hide_fields_action');
-        button_wrapper.append(button);
+        button_wrapper.appendChild(button);
 
         form.querySelector(':scope [name="country_id"]').closest('.field-wrapper').after(button_wrapper);
       }
@@ -93,7 +93,7 @@ function cc_m2_c2a() {
 
       if (c2a_config.autocomplete.advanced.lock_country_to_dropdown) {
         if (c2a_config.autocomplete.advanced.use_first_line) {
-          form.querySelector(':scope .cc_search_input').closest('fieldset').before(form.querySelector(':scope [name="country_id"]').closest('div.field'));
+          form.querySelector(':scope .cc_search_input').closest('div.field').before(form.querySelector(':scope [name="country_id"]').closest('div.field'));
         } else {
           form.querySelector(':scope .cc_search_input').closest('div.field').before(form.querySelector(':scope [name="country_id"]').closest('div.field'));
         }
@@ -159,19 +159,19 @@ function activate_cc_m2_uk() {
       ui: {
         onResultSelected: function(dataset, id, fields) {
           //fields.postcode.closest('form').querySelector(':scope .cp_manual_entry').style.display = 'none';
-          if (fields.address_4.length) {
-            fields.address_4[0].value = '';
+          if (fields.address_4) {
+            fields.address_4.value = '';
           }
 
-          fields.company[0]?.dispatchEvent(new Event('input'));
-          fields.address_1[0]?.dispatchEvent(new Event('input'));
-          fields.address_2[0]?.dispatchEvent(new Event('input'));
-          fields.address_3[0]?.dispatchEvent(new Event('input'));
-          fields.address_4[0]?.dispatchEvent(new Event('input'));
-          fields.postcode[0]?.dispatchEvent(new Event('input'));
-          fields.town[0]?.dispatchEvent(new Event('input'));
-          fields.county[0]?.dispatchEvent(new Event('input'));
-          fields.county_list[0]?.dispatchEvent(new Event('change'));
+          if (fields.company) fields.company.dispatchEvent(new Event('input'));
+          if (fields.address_1) fields.address_1.dispatchEvent(new Event('input'));
+          if (fields.address_2) fields.address_2.dispatchEvent(new Event('input'));
+          if (fields.address_3) fields.address_3.dispatchEvent(new Event('input'));
+          if (fields.address_4) fields.address_4.dispatchEvent(new Event('input'));
+          if (fields.postcode) fields.postcode.dispatchEvent(new Event('input'));
+          if (fields.town) fields.town.dispatchEvent(new Event('input'));
+          if (fields.county) fields.county.dispatchEvent(new Event('input'));
+          if (fields.county_list) fields.county_list.dispatchEvent(new Event('change'));
         }
       }
     };
@@ -189,8 +189,7 @@ function activate_cc_m2_uk() {
       country:  '[name="country_id"]'
     };
 
-    var postcode_elements = document.querySelectorAll(dom.postcode);
-    postcode_elements.forEach((postcode_elem, index) => {
+    document.querySelectorAll(dom.postcode).forEach((postcode_elem) => {
       /**
        * The Magento 2 checkout loads fields
        * asynchronously so we need to check
@@ -210,16 +209,16 @@ function activate_cc_m2_uk() {
         cc_index++;
 
         active_cfg.dom = {
-          company:    jQuery(form).find(dom.company),
-          address_1:    jQuery(form).find(dom.address_1),
-          address_2:    jQuery(form).find(dom.address_2),
-          address_3:    jQuery(form).find(dom.address_3),
-          address_4:    jQuery(form).find(dom.address_4),
-          postcode:    jQuery(postcode_elem),
-          town:      jQuery(form).find(dom.town),
-          county:      jQuery(form).find(dom.county),
-          county_list:  jQuery(form).find(dom.county_list),
-          country:    jQuery(form).find(dom.country)
+          company:    form.querySelector(dom.company),
+          address_1:    form.querySelector(dom.address_1),
+          address_2:    form.querySelector(dom.address_2),
+          address_3:    form.querySelector(dom.address_3),
+          address_4:    form.querySelector(dom.address_4),
+          postcode:    postcode_elem,
+          town:      form.querySelector(dom.town),
+          county:      form.querySelector(dom.county),
+          county_list:  form.querySelector(dom.county_list),
+          country:    form.querySelector(dom.country)
         };
 
         // STANDARD
@@ -311,24 +310,24 @@ function activate_cc_m2_uk() {
             style.textContent = '.crafty_address_field_hidden { display: none; }';
             document.head.appendChild(style);
 
-            active_cfg.dom.address_1[0]?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
-            active_cfg.dom.address_2[0]?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
-            active_cfg.dom.address_3[0]?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
-            active_cfg.dom.address_4[0]?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
-            active_cfg.dom.company[0]?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
-            active_cfg.dom.county[0]?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
-            active_cfg.dom.county_list[0]?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
-            active_cfg.dom.town[0]?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
+            active_cfg.dom.address_1?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
+            active_cfg.dom.address_2?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
+            active_cfg.dom.address_3?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
+            active_cfg.dom.address_4?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
+            active_cfg.dom.company?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
+            active_cfg.dom.county?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
+            active_cfg.dom.county_list?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
+            active_cfg.dom.town?.closest('.field').classList.add('crafty_address_field', 'crafty_address_field_hidden');
 
             document.getElementById('shipping-country_id').addEventListener('change', () => {
               var active_countries = ['GB', 'IM', 'JE', 'GG'];
               if (active_countries.indexOf(this.value) !== -1) {
-                form.querySelectorAll('.crafty_address_field:not(.crafty_address_field_hidden)').forEach((element, index) => {
+                form.querySelectorAll('.crafty_address_field:not(.crafty_address_field_hidden)').forEach((element) => {
                   element.classList.add('crafty_address_field_hidden');
                 });
                 document.getElementById(active_cfg.id + '_cp_manual_entry').style.display = 'block';
               } else {
-                form.querySelectorAll('.crafty_address_field.crafty_address_field_hidden').forEach((element, index) => {
+                form.querySelectorAll('.crafty_address_field.crafty_address_field_hidden').forEach((element) => {
                   element.classList.remove('crafty_address_field_hidden');
                 });
                 document.getElementById(active_cfg.id + '_cp_manual_entry').style.display = 'none';
@@ -336,7 +335,7 @@ function activate_cc_m2_uk() {
             });
 
             document.getElementById(active_cfg.id + '_cp_manual_entry').addEventListener('click', () => {
-              form.querySelectorAll('.crafty_address_field').forEach((element, index) => {
+              form.querySelectorAll('.crafty_address_field').forEach((element) => {
                 element.classList.remove('crafty_address_field_hidden');
               });
               document.getElementById(active_cfg.id + '_cp_manual_entry').style.display = 'none';
@@ -396,7 +395,7 @@ function cc_hide_fields(dom, action) {
       break;
     case 'hide':
       var form = dom.country.closest('form');
-      form.querySelectorAll(':scope .cc_hide').forEach((item, index) => {
+      form.querySelectorAll(':scope .cc_hide').forEach((item) => {
         item.classList.add('cc_hidden');
       });
       form.querySelector(':scope .cc_hide_fields_action').classList.remove('cc_slider_on');
@@ -405,7 +404,7 @@ function cc_hide_fields(dom, action) {
     case 'manual-show':
     case 'show':
       var form = dom.country.closest('form');
-      form.querySelectorAll(':scope .cc_hide').forEach((item, index) => {
+      form.querySelectorAll(':scope .cc_hide').forEach((item) => {
         item.classList.remove('cc_hidden');
       });
       form.querySelector(':scope .cc_hide_fields_action').style.display = 'none';
@@ -425,7 +424,7 @@ function cc_hide_fields(dom, action) {
 function cc_reveal_fields_on_error(dom) {
   var form = dom.country.closest('form');
   var errors_present = false;
-  form.querySelectorAll(':scope .cc_hide').forEach((item, index) => {
+  form.querySelectorAll(':scope .cc_hide').forEach((item) => {
     if (item.classList.contains('_error')) {
       errors_present = true;
     }
@@ -541,7 +540,7 @@ window.addEventListener('load', function () {
 
     setInterval(function() {
       var email_elements = document.querySelectorAll('input[name="email_address"]');
-      email_elements.forEach((email_element, index) => {
+      email_elements.forEach((email_element) => {
         if (cc_applied_email.indexOf(email_element.id) === -1) {
           cc_applied_email.push(email_element.id);
           window.cc_holder.addEmailVerify({
@@ -561,7 +560,7 @@ window.addEventListener('load', function () {
 
     setInterval(function() {
       var phone_elements = document.querySelectorAll('input[name="telephone"]');
-      phone_elements.forEach((phone_element, index) => {
+      phone_elements.forEach((phone_element) => {
         if (cc_applied_phone.indexOf(phone_element.id) === -1) {
           cc_applied_phone.push(phone_element.id);
           var country = phone_element.closest('form').querySelector(':scope select[name="country_id"]');

--- a/view/frontend/web/form_integrations/cc_multishipping_address.js
+++ b/view/frontend/web/form_integrations/cc_multishipping_address.js
@@ -4,77 +4,118 @@ function cc_m2_c2a() {
 	 * (needed on sites that load page elements
 	 * via multiple ajax requests)
 	 */
-	if (jQuery('[name="postcode"]').length == 0) {
+	if (!document.querySelector('[name="postcode"]')) {
 		return;
 	}
 
-	jQuery('[name="postcode"]').each(function(index, elem) {
-		if (jQuery(elem).data('cc_attach') != '1') {
-			jQuery(elem).data('cc_attach', '1');
+	document.querySelectorAll('[name="postcode"]').forEach(function(postcode_elem) {
+		if (postcode_elem.dataset.cc_attach != '1') {
+			postcode_elem.dataset.cc_attach = '1';
 
-			var form = jQuery(elem).closest('form');
-			var custom_id = '';
+			var form = postcode_elem.closest('form');
 
-			if (c2a_config.autocomplete.advanced.search_elem_id !== null) {
-				custom_id = ' id="' + c2a_config.autocomplete.advanced.search_elem_id + '"';
-			}
-			
 			// null fix for m2_1.1.16
 			if (c2a_config.autocomplete.texts.search_label == null) c2a_config.autocomplete.texts.search_label = '';
 			
-			var tmp_html = '<div class="field"' + custom_id + '><label class="label" for="fetchify_search">' +
-			c2a_config.autocomplete.texts.search_label + '</label>' +
-			'<div class="control"><input class="cc_search_input" type="text" name="fetchify_search"/></div></div>';
+			var search_elem = document.createElement('input');
+			search_elem.classList.add('cc_search_input');
+			search_elem.name = 'fetchify_search';
+			search_elem.setAttribute('type', 'text');
 
-			if (c2a_config.autocomplete.advanced.hide_fields) {
-				var svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 305.67 179.25">' +
-				'<rect x="-22.85" y="66.4" width="226.32" height="47.53" rx="17.33" ry="17.33" transform="translate(89.52 -37.99) rotate(45)"/>' +
-				'<rect x="103.58" y="66.4" width="226.32" height="47.53" rx="17.33" ry="17.33" transform="translate(433.06 0.12) rotate(135)"/>' +
-				'</svg>';
-				tmp_html += '<div class="field cc_hide_fields_action"><label>' + c2a_config.autocomplete.texts.manual_entry_toggle + '</label>' + svg + '</div>';
-			}
+			var small_wrapper_elem = document.createElement('div');
+			small_wrapper_elem.classList.add('control');
+			small_wrapper_elem.appendChild(search_elem);
+
+			var label_elem = document.createElement('label');
+			label_elem.classList.add('label');
+			label_elem.setAttribute('for', 'fetchify_search');
+			label_elem.textContent = c2a_config.autocomplete.texts.search_label_elem;
+
+			var big_wrapper_elem = document.createElement('div');
+			if (c2a_config.autocomplete.advanced.search_elem_id !== null) { big_wrapper_elem.id = c2a_config.autocomplete.advanced.search_elem_id; } // custom id
+			big_wrapper_elem.classList.add('field');
+			big_wrapper_elem.appendChild(label_elem);
+			big_wrapper_elem.appendChild(small_wrapper_elem);
 
 			if (!c2a_config.autocomplete.advanced.use_first_line || c2a_config.autocomplete.advanced.hide_fields) {
-				form.find('#street_1').closest('div.street').before(tmp_html);
+				form.querySelector('#street_1').closest('div.street').before(big_wrapper_elem);
 			} else {
-				form.find('#street_1').addClass('cc_search_input');
+				form.querySelector('#street_1').classList.add('cc_search_input');
+			}
+
+			if (c2a_config.autocomplete.advanced.hide_fields) {
+				var rect1_elem = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+				rect1_elem.setAttribute('x', '-22.85');
+				rect1_elem.setAttribute('y', '66.4');
+				rect1_elem.setAttribute('width', '226.32');
+				rect1_elem.setAttribute('height', '47.53');
+				rect1_elem.setAttribute('rx', '17.33');
+				rect1_elem.setAttribute('ry', '17.33');
+				rect1_elem.setAttribute('transform', 'translate(89.52 -37.99) rotate(45)');
+
+				var rect2_elem = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+				rect2_elem.setAttribute('x', '103.58');
+				rect2_elem.setAttribute('y', '66.4');
+				rect2_elem.setAttribute('width', '226.32');
+				rect2_elem.setAttribute('height', '47.53');
+				rect2_elem.setAttribute('rx', '17.33');
+				rect2_elem.setAttribute('ry', '17.33');
+				rect2_elem.setAttribute('transform', 'translate(433.06 0.12) rotate(135)');
+
+				var svg_elem = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+				svg_elem.setAttribute('viewBox', '0 0 305.67 179.25');
+				svg_elem.appendChild(rect1_elem);
+				svg_elem.appendChild(rect2_elem);
+
+				var manual_entry_label_elem = document.createElement('label');
+				manual_entry_label_elem.innerText = c2a_config.autocomplete.texts.manual_entry_toggle;
+				manual_entry_label_elem.style.cursor = 'pointer';
+
+				var manual_entry_wrapper_elem = document.createElement('div');
+				manual_entry_wrapper_elem.classList.add('field', 'cc_hide_fields_action');
+				manual_entry_wrapper_elem.appendChild(manual_entry_label_elem);
+				manual_entry_wrapper_elem.appendChild(svg_elem);
+
+				big_wrapper_elem.after(manual_entry_wrapper_elem);
 			}
 
 			if (c2a_config.autocomplete.advanced.lock_country_to_dropdown) {
-				form.find('.cc_search_input').closest('div.field').before(form.find('[name="country_id"]').closest('div.field'));
+				form.querySelector('.cc_search_input').closest('div.field').before(form.querySelector('[name="country_id"]').closest('div.field'));
 			}
 
 			var dom = {
-				search:		form.find('.cc_search_input'),
-				company:	form.find('[name="company"]'),
-				line_1:		form.find('#street_1'),
-				line_2:		form.find('#street_2'),
-				postcode:	form.find('[name="postcode"]'),
-				town:		form.find('[name="city"]'),
+				search:		form.querySelector('.cc_search_input'),
+				company:	form.querySelector('[name="company"]'),
+				line_1:		form.querySelector('#street_1'),
+				line_2:		form.querySelector('#street_2'),
+				postcode:	form.querySelector('[name="postcode"]'),
+				town:		form.querySelector('[name="city"]'),
 				county: {
-					input: form.find('[name="region"]'),
-					list: form.find('[name="region_id"]')
+					input: form.querySelector('[name="region"]'),
+					list: form.querySelector('[name="region_id"]')
 				},
-				country:	form.find('[name="country_id"]')
+				country:	form.querySelector('[name="country_id"]')
 			};
 
 			window.cc_holder.attach({
-				search:		dom.search[0],
-				company:	dom.company[0],
-				line_1:		dom.line_1[0],
-				line_2:		dom.line_2[0],
-				postcode:	dom.postcode[0],
-				town:		dom.town[0],
+				search:		dom.search,
+				company:	dom.company,
+				line_1:		dom.line_1,
+				line_2:		dom.line_2,
+				postcode:	dom.postcode,
+				town:		dom.town,
 				county: {
 					input: dom.county.input,
 					list: dom.county.list
 				},
-				country:	dom.country[0]
+				country:	dom.country
 			});
 
-			form.find('.cc_hide_fields_action').on('click', function() {
-				cc_hide_fields(dom, 'manual-show');
-			});
+			if (c2a_config.autocomplete.advanced.hide_fields) {
+				form.querySelector('.cc_hide_fields_action').addEventListener('click', () => {
+					cc_hide_fields(dom, 'manual-show');
+				});
+			}
 
 			cc_hide_fields(dom, 'init');
 		}
@@ -83,47 +124,18 @@ function cc_m2_c2a() {
 
 window.cc_holder = null;
 
+function parents(el, selector) {
+  var parents = [];
+  while ((el = el.parentNode) && el !== document) {
+    if (!selector || el.matches(selector)) parents.push(el);
+  }
+  return parents;
+}
+
 // Postcode Lookup
 function activate_cc_m2_uk() {
 	// TODO: arrange fields based on country
 	if (c2a_config.postcodelookup.enabled) {
-		var cfg = {
-			id: '',
-			core: {
-				key: c2a_config.main.key,
-				preformat: true,
-				capsformat: {
-					address: true,
-					organization: true,
-					county: true,
-					town: true
-				}
-			},
-			dom: {},
-			sort_fields: {
-				active: true,
-				parent: '.field:not(.additional)'
-			},
-			hide_fields: c2a_config.postcodelookup.hide_fields,
-			txt: c2a_config.postcodelookup.txt,
-			error_msg: c2a_config.postcodelookup.error_msg,
-			county_data: c2a_config.postcodelookup.advanced.county_data,
-			ui: {
-				onResultSelected: function(dataset, id, fields) {
-					if (cfg.county_data == 'former_postal') {
-						fields.county[0].value = dataset.postal_county;
-					} else if (cfg.county_data == 'traditional') {
-						fields.county[0].value = dataset.traditional_county;
-					} else {
-						fields.county[0].value = '';
-					}
-					fields.county.trigger('change');
-					fields.postcode.closest('form').find('.cp_manual_entry').hide(200);
-					fields.address_4.val('').change();
-				}
-			}
-		};
-
 		var dom = {
 			company:	'[name="company"]',
 			address_1:	'#street_1',
@@ -137,8 +149,7 @@ function activate_cc_m2_uk() {
 			country:	'[name="country_id"]'
 		};
 
-		var postcode_elements = jQuery(dom.postcode);
-		postcode_elements.each(function(index) {
+		document.querySelectorAll(dom.postcode).forEach(function(postcode_elem) {
 			/**
 			 * The Magento 2 checkout loads fields
 			 * asynchronously so we need to check 
@@ -147,90 +158,180 @@ function activate_cc_m2_uk() {
 			 * a race condition scenario on slow 
 			 * devices/connections.
 			 */
-			var form = postcode_elements.eq(index).closest('form');
+			var form = postcode_elem.closest('form');
 			if (
-				postcode_elements.eq(index).attr('cc_pcl_applied') != '1'
-				&& form.find(dom.address_1).length === 1
-				&& form.find(dom.country).length === 1
+				postcode_elem.dataset.cc_pcl_applied != '1'
+				&& form.querySelector(dom.address_1)
+				&& form.querySelector(dom.country)
 			) {
-				var active_cfg = {};
-				jQuery.extend(active_cfg, cfg);
-				active_cfg.id = 'm2_' + cc_index;
-				cc_index++;
-
-				active_cfg.dom = {
-					company:		form.find(dom.company),
-					address_1:		form.find(dom.address_1),
-					address_2:		form.find(dom.address_2),
-					address_3:		form.find(dom.address_3),
-					address_4:		form.find(dom.address_4),
-					postcode:		postcode_elements.eq(index),
-					town:			form.find(dom.town),
-					county:			form.find(dom.county),
-					county_list:	form.find(dom.county_list),
-					country:		form.find(dom.country)
+				var active_cfg = {
+					id: 'm2_' + cc_index,
+					core: {
+						key: c2a_config.main.key,
+						preformat: true,
+						capsformat: {
+							address: true,
+							organization: true,
+							county: true,
+							town: true
+						}
+					},
+					dom: {
+						company:		form.querySelector(dom.company),
+						address_1:		form.querySelector(dom.address_1),
+						address_2:		form.querySelector(dom.address_2),
+						address_3:		form.querySelector(dom.address_3),
+						address_4:		form.querySelector(dom.address_4),
+						postcode:		postcode_elem,
+						town:			form.querySelector(dom.town),
+						county:			form.querySelector(dom.county),
+						county_list:	form.querySelector(dom.county_list),
+						country:		form.querySelector(dom.country)
+					},
+					sort_fields: {
+						active: true,
+						parent: '.field:not(.additional)'
+					},
+					hide_fields: c2a_config.postcodelookup.hide_fields,
+					txt: c2a_config.postcodelookup.txt,
+					error_msg: c2a_config.postcodelookup.error_msg,
+					county_data: c2a_config.postcodelookup.advanced.county_data,
+					ui: {
+						onResultSelected: function(dataset, id, fields) {
+							if (active_cfg.county_data == 'former_postal') {
+								fields.county.value = dataset.postal_county;
+							} else if (active_cfg.county_data == 'traditional') {
+								fields.county.value = dataset.traditional_county;
+							} else {
+								fields.county.value = '';
+							}
+							if (fields.county) fields.county.dispatchEvent(new Event('change'));
+							fields.postcode.closest('form').querySelector('.cp_manual_entry').style.display = 'none';
+							if (fields.address_4) {
+								fields.address_4.value = '';
+								fields.address_4.dispatchEvent(new Event('change'));
+							}
+						}
+					}
 				};
 
+				cc_index++;
+
 				// modify the Layout
-				var postcode_elem = active_cfg.dom.postcode;
-				postcode_elem.wrap('<div class="search-bar"></div>');
-				postcode_elem.before('<button type="button" class="action primary">' +
-					'<span>' + active_cfg.txt.search_buttontext + '</span></button>');
+				var postcode_wrapper_elem = document.createElement('div');
+				postcode_wrapper_elem.classList.add('search-bar');
+				postcode_elem.replaceWith(postcode_wrapper_elem);
+				postcode_wrapper_elem.appendChild(postcode_elem);
 
 				// STANDARD
-				postcode_elem.closest('.search-bar').after('<div class="search-list" style="display: none;"><select></select></div>' +
-					'<div class="mage-error" generated><div class="search-subtext"></div></div>');
+				var button_text_elem = document.createElement('span');
+				button_text_elem.textContent = active_cfg.txt.search_buttontext;
+
+				var button_elem = document.createElement('button');
+				button_elem.setAttribute('type', 'button'); // Required to prevent form from submitting
+				button_elem.classList.add('action', 'primary');
+				button_elem.appendChild(button_text_elem);
+				postcode_wrapper_elem.appendChild(button_elem);
+
+				var error_elem = document.createElement('div');
+				error_elem.classList.add('search-subtext');
+
+				var error_wrapper_elem = document.createElement('div');
+				error_wrapper_elem.classList.add('mage-error');
+				error_wrapper_elem.setAttribute('generated', '');
+				error_wrapper_elem.appendChild(error_elem);
+				postcode_wrapper_elem.after(error_wrapper_elem);
+
+				var results_elem = document.createElement('select');
+
+				var results_wrapper_elem = document.createElement('div');
+				results_wrapper_elem.classList.add('search-list');
+				results_wrapper_elem.style.display = 'none';
+				results_wrapper_elem.appendChild(results_elem);
+				postcode_wrapper_elem.after(results_wrapper_elem);
 
 				/* m2 expects the alert elem to be directly after postcode 
 				input, so let's move it back there to prevent m2 using our 
 				button for displaying invalid postcode error text */
-				postcode_elem.after(postcode_elem.closest('.control').find('[role="alert"]'));
+				postcode_elem.after(postcode_elem.closest('.control').querySelector('[role="alert"]'));
 
 				// input after postcode
 				var new_container = postcode_elem.closest(active_cfg.sort_fields.parent);
-				new_container.addClass('search-container').attr('id', active_cfg.id).addClass('type_3');
+				new_container.id = active_cfg.id;
+				new_container.classList.add('search-container', 'type_3');
 
 				// add/show manual entry text
 				if (active_cfg.hide_fields) {
-					if (jQuery('#' + active_cfg.id + '_cp_manual_entry').length === 0 && postcode_elem.val() === '') {
-						var svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 305.67 179.25">' +
-							'<rect x="-22.85" y="66.4" width="226.32" height="47.53" rx="17.33" ry="17.33" transform="translate(89.52 -37.99) rotate(45)"/>' +
-							'<rect x="103.58" y="66.4" width="226.32" height="47.53" rx="17.33" ry="17.33" transform="translate(433.06 0.12) rotate(135)"/>' +
-							'</svg>';
-						tmp_manual_html = '<div class="field cp_manual_entry" id="' + active_cfg.id + '_cp_manual_entry"><label>' + active_cfg.txt.manual_entry + '</label>' + svg + '</div>';
-						jQuery(postcode_elem).closest('.field').after(tmp_manual_html);
+					if (!document.getElementById(active_cfg.id + '_cp_manual_entry') && postcode_elem.value === '') {
+						var rect1_elem = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+						rect1_elem.setAttribute('x', '-22.85');
+						rect1_elem.setAttribute('y', '66.4');
+						rect1_elem.setAttribute('width', '226.32');
+						rect1_elem.setAttribute('height', '47.53');
+						rect1_elem.setAttribute('rx', '17.33');
+						rect1_elem.setAttribute('ry', '17.33');
+						rect1_elem.setAttribute('transform', 'translate(89.52 -37.99) rotate(45)');
 
-						jQuery('#' + active_cfg.id + '_cp_manual_entry').on('click', function() {
-							jQuery(form).find('.crafty_address_field').removeClass('crafty_address_field_hidden');
-							jQuery('#' + active_cfg.id + '_cp_manual_entry').hide(200);
+						var rect2_elem = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+						rect2_elem.setAttribute('x', '103.58');
+						rect2_elem.setAttribute('y', '66.4');
+						rect2_elem.setAttribute('width', '226.32');
+						rect2_elem.setAttribute('height', '47.53');
+						rect2_elem.setAttribute('rx', '17.33');
+						rect2_elem.setAttribute('ry', '17.33');
+						rect2_elem.setAttribute('transform', 'translate(433.06 0.12) rotate(135)');
+
+						var svg_elem = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+						svg_elem.setAttribute('viewBox', '0 0 305.67 179.25');
+						svg_elem.setAttribute('style', 'display: inline-block; width: 1em;');
+						svg_elem.appendChild(rect1_elem);
+						svg_elem.appendChild(rect2_elem);
+
+						var manual_entry_label_elem = document.createElement('label');
+						manual_entry_label_elem.textContent = active_cfg.txt.manual_entry;
+						manual_entry_label_elem.style.cursor = 'pointer';
+
+						var manual_entry_wrapper_elem = document.createElement('div');
+						manual_entry_wrapper_elem.id = active_cfg.id + '_cp_manual_entry';
+						manual_entry_wrapper_elem.classList.add('field', 'cp_manual_entry');
+						manual_entry_wrapper_elem.appendChild(manual_entry_label_elem);
+						manual_entry_wrapper_elem.appendChild(svg_elem);
+
+						postcode_elem.closest('.field').after(manual_entry_wrapper_elem);
+
+						document.getElementById(active_cfg.id + '_cp_manual_entry').addEventListener('click', () => {
+							form.querySelectorAll('.crafty_address_field').forEach((element) => {
+								element.classList.remove('crafty_address_field_hidden');
+							});
+							document.getElementById(active_cfg.id + '_cp_manual_entry').style.display = 'none';
 						});
 					}
 				}
 
-				active_cfg.dom.postcode.attr('cc_pcl_applied', '1');
+				postcode_elem.dataset.cc_pcl_applied = '1';
 				cc_generic = new cc_ui_handler(active_cfg);
 
 				// respect the form's two-column layout
 				cc_generic.sort = function() {
 					var elems = this.cfg.dom;
-					var country = elems.country.parents(this.cfg.sort_fields.parent).last();
-					var line_1 = elems.address_1.parents(this.cfg.sort_fields.parent).last();
+					var country = parents(elems.country, this.cfg.sort_fields.parent).at(-1);
+					var line_1 = parents(elems.address_1, this.cfg.sort_fields.parent).at(-1);
 					var searchContainer = {};
 
-					country.insertBefore(line_1);
-					searchContainer = this.search_object;
+					line_1.before(country);
+					searchContainer = this.search_object[0];
 					country.after(searchContainer);
 
 					//IWD checkout - temporary ???
-					if (jQuery('.crafty-results-container').length > 0) {
-						searchContainer.after(searchContainer.closest('.fieldset').find('.crafty-results-container'));
+					if (document.querySelector('.crafty-results-container')) {
+						searchContainer.after(searchContainer.closest('.fieldset').querySelector('.crafty-results-container'));
 					}
 
 					if (this.cfg.hide_fields) {
 						var tagElement = [];
 						tagElement = ['company', 'address_1', 'town', 'county', 'county_list'];
 						for (var i = 0; i < tagElement.length; i++) {
-							elems[tagElement[i]].parents(this.cfg.sort_fields.parent).last().addClass('crafty_address_field');
+							parents(elems[tagElement[i]], this.cfg.sort_fields.parent).at(-1).classList.add('crafty_address_field');
 						}
 					}
 				};
@@ -254,7 +355,7 @@ function cc_hide_fields(dom, action) {
 			var elementsToHide = ['line_1', 'line_2', 'line_3', 'line_4', 'town', 'postcode', 'county'];
 			var formEmpty = true;
 			for (var i = 0; i < elementsToHide.length - 1; i++) { // -1 is to skip County
-				if (jQuery(dom[elementsToHide[i]]).length && jQuery(dom[elementsToHide[i]]).val() !== '') {
+				if (dom[elementsToHide[i]] && dom[elementsToHide[i]].value !== '') {
 					formEmpty = false;
 				}
 			}
@@ -264,24 +365,24 @@ function cc_hide_fields(dom, action) {
 			}
 
 			for (var i = 0; i < elementsToHide.length; i++) {
-				if (jQuery(dom[elementsToHide[i]]).length) {
+				if (dom[elementsToHide[i]]) {
 					switch (elementsToHide[i]) {
 						case 'county':
-							jQuery(dom[elementsToHide[i]].input).closest('.field').addClass('cc_hide');
-							jQuery(dom[elementsToHide[i]].list).closest('.field').addClass('cc_hide');
+							dom[elementsToHide[i]].input.closest('.field').classList.add('cc_hide');
+							dom[elementsToHide[i]].list.closest('.field').classList.add('cc_hide');
 							break;
 						case 'line_1':
-							jQuery(dom[elementsToHide[i]]).closest('div.street').addClass('cc_hide');
+							dom[elementsToHide[i]].closest('div.street').classList.add('cc_hide');
 							break;
 						default:
-							jQuery(dom[elementsToHide[i]]).closest('.field').addClass('cc_hide');
+							dom[elementsToHide[i]].closest('.field').classList.add('cc_hide');
 					}
 				}
 			}
 
 			// store the checking loop in the DOM object
-			var form = jQuery(dom.country).closest('form');
-			form.data('cc_hidden', 0);
+			var form = dom.country.closest('form');
+			form.dataset.cc_hidden = '0';
 			if (formEmpty) {
 				cc_hide_fields(dom, 'hide');
 			} else {
@@ -291,31 +392,31 @@ function cc_hide_fields(dom, action) {
 			setInterval(function() { cc_reveal_fields_on_error(dom); }, 250);
 			break;
 		case 'hide':
-			var form = jQuery(dom.country).closest('form');
-			form.find('.cc_hide').each(function(index, item) {
-				jQuery(item).addClass('cc_hidden');
+			var form = dom.country.closest('form');
+			form.querySelectorAll('.cc_hide').forEach(function(item) {
+				item.classList.add('cc_hidden');
 			});
-			form.find('.cc_hide_fields_action').removeClass('cc_slider_on');
-			form.data('cc_hidden', 1);
+			form.querySelector('.cc_hide_fields_action').classList.remove('cc_slider_on');
+			form.dataset.cc_hidden = '1';
 			break;
 		case 'manual-show':
 		case 'show':
-			jQuery(dom.country).trigger('change');
+			dom.country.dispatchEvent(new Event('change'));
 
-			var form = jQuery(dom.country).closest('form');
-			form.find('.cc_hide').each(function(index, item) {
-				jQuery(item).removeClass('cc_hidden');
+			var form = dom.country.closest('form');
+			form.querySelectorAll('.cc_hide').forEach(function(item) {
+				item.classList.remove('cc_hidden');
 			});
-			form.find('.cc_hide_fields_action').hide(200);
-			form.data('cc_hidden', 0);
+			form.querySelector('.cc_hide_fields_action').style.display = 'none';
+			form.dataset.cc_hidden = '0';
 
 			if (action == 'manual-show') {
-				jQuery(dom.country).trigger('change');
+				dom.country.dispatchEvent(new Event('change'));
 			}
 			break;
 		case 'toggle':
-			var form = jQuery(dom.country).closest('form');
-			if (form.data('cc_hidden') == 1) {
+			var form = dom.country.closest('form');
+			if (form.dataset.cc_hidden == '1') {
 				cc_hide_fields(dom, 'show');
 			} else {
 				cc_hide_fields(dom, 'hide');
@@ -325,170 +426,163 @@ function cc_hide_fields(dom, action) {
 }
 
 function cc_reveal_fields_on_error(dom) {
-	var form = jQuery(dom.country).closest('form');
+	var form = dom.country.closest('form');
 	var errors_present = false;
 
-	form.find('.cc_hide').each(function(index, item) {
-		if (jQuery(item).hasClass('_error')) {
+	form.querySelectorAll('.cc_hide').forEach(function(item) {
+		if (item.classList.contains('_error')) {
 			errors_present = true;
 		}
 	});
 
 	if (errors_present) {
 		cc_hide_fields(dom, 'show');
-		form.find('.cc_hide_fields_action').hide(); // prevent the user from hiding the fields again
+		form.querySelector('.cc_hide_fields_action').style.display = 'none'; // prevent the user from hiding the fields again
 	}
 }
-requirejs(['jquery'], function($) {
-	jQuery(document).ready(function() {
-		if (!c2a_config.main.enable_extension) { return; }
 
-		if (c2a_config.autocomplete.enabled && c2a_config.main.key != null) {
-			var config = {
-				accessToken: c2a_config.main.key,
-				onSetCounty: function(c2a, elements, county) {
-					return;
-				},
-				domMode: 'object',
-				gfxMode: c2a_config.autocomplete.gfx_mode,
-				style: {
-					ambient: c2a_config.autocomplete.gfx_ambient,
-					accent: c2a_config.autocomplete.gfx_accent
-				},
-				showLogo: false,
-				texts: c2a_config.autocomplete.texts,
-				onResultSelected: function(c2a, elements, address) {
-					var postcode = address.postal_code.substring(0, 2);
+function cc_init() {
+	if (!c2a_config.main.enable_extension) { return; }
 
-					switch (postcode) {
-						case 'JE':
-						case 'GG':
-						case 'IM':
-							jQuery(elements.country).val(postcode);
-							break;
-						default:
-							jQuery(elements.country).val(address.country.iso_3166_1_alpha_2);
-					}
+	if (c2a_config.autocomplete.enabled && c2a_config.main.key != null) {
+		var config = {
+			accessToken: c2a_config.main.key,
+			onSetCounty: function(c2a, elements, county) {
+				return;
+			},
+			domMode: 'object',
+			gfxMode: c2a_config.autocomplete.gfx_mode,
+			style: {
+				ambient: c2a_config.autocomplete.gfx_ambient,
+				accent: c2a_config.autocomplete.gfx_accent
+			},
+			showLogo: false,
+			texts: c2a_config.autocomplete.texts,
+			onResultSelected: function(c2a, elements, address) {
+				var postcode = address.postal_code.substring(0, 2);
 
-					if (typeof elements.country != 'undefined') { triggerEvent('change', elements.country); }
+				switch (postcode) {
+					case 'JE':
+					case 'GG':
+					case 'IM':
+						elements.country.value = postcode;
+						break;
+					default:
+						elements.country.value = address.country.iso_3166_1_alpha_2;
+				}
 
-					var county;
-					if (c2a.activeCountry === 'gbr' && !c2a_config.autocomplete.advanced.fill_uk_counties) {
-						county = { code: '', name: '', preferred: '' };
-					} else {
-						county = {
-							preferred: address.province,
-							code: address.province_code,
-							name: address.province_name
-						};
-					}
+				if (typeof elements.country != 'undefined') { elements.country.dispatchEvent(new Event('change')); }
 
-					if (elements.county.list.length == 1) {
-						c2a.setCounty(elements.county.list[0], county);
-					}
+				var county;
+				if (c2a.activeCountry === 'gbr' && !c2a_config.autocomplete.advanced.fill_uk_counties) {
+					county = { code: '', name: '', preferred: '' };
+				} else {
+					county = {
+						preferred: address.province,
+						code: address.province_code,
+						name: address.province_name
+					};
+				}
 
-					if (elements.county.input.length == 1) {
-						c2a.setCounty(elements.county.input[0], county);
-					}
+				if (elements.county.list) {
+					c2a.setCounty(elements.county.list, county);
+				}
 
-					if (typeof elements.county.input[0] != 'undefined') triggerEvent('change', elements.county.input[0]);
-					if (typeof elements.county.list[0] != 'undefined') triggerEvent('change', elements.county.list[0]);
-					if (typeof elements.company != 'undefined') triggerEvent('change', elements.company);
-					if (typeof elements.line_1 != 'undefined') triggerEvent('change', elements.line_1);
-					if (typeof elements.line_2 != 'undefined') triggerEvent('change', elements.line_2);
-					if (typeof elements.postcode != 'undefined') triggerEvent('change', elements.postcode);
-					if (typeof elements.town != 'undefined') triggerEvent('change', elements.town);
+				if (elements.county.input) {
+					c2a.setCounty(elements.county.input, county);
+				}
 
-					var line_3 = jQuery(elements.search).closest('form').find('#street_3');
-					if (line_3.length !== 0) {
-						line_3.val('');
-						triggerEvent('change', line_3[0]);
-					}
-					
-					var line_4 = jQuery(elements.search).closest('form').find('#street_4');
-					if (line_4.length !== 0) {
-						line_4.val('');
-						triggerEvent('change', line_4[0]);
-					}
+				if (elements.county.input) elements.county.input.dispatchEvent(new Event('change'));
+				if (elements.county.list) elements.county.list.dispatchEvent(new Event('change'));
+				if (elements.company) elements.company.dispatchEvent(new Event('change'));
+				if (elements.line_1) elements.line_1.dispatchEvent(new Event('change'));
+				if (elements.line_2) elements.line_2.dispatchEvent(new Event('change'));
+				if (elements.postcode) elements.postcode.dispatchEvent(new Event('change'));
+				if (elements.town) elements.town.dispatchEvent(new Event('change'));
 
-					cc_hide_fields(elements, 'show');
-				},
-				onError: function() {
-					if (typeof this.activeDom.postcode !== 'undefined') {
-						cc_hide_fields(this.activeDom, 'show');
-					} else {
-						c2a_config.autocomplete.advanced.hide_fields = false;
-					}
-				},
-				transliterate: c2a_config.autocomplete.advanced.transliterate,
-				excludeAreas: c2a_config.autocomplete.exclusions.areas,
-				excludePoBox: c2a_config.autocomplete.exclusions.po_box,
-				debug: c2a_config.autocomplete.advanced.debug,
-				cssPath: false,
-				tag: 'magento2'
+				var line_3 = elements.search.closest('form').querySelector('#street_3');
+				if (line_3) {
+					line_3.value = '';
+					elements.line_3.dispatchEvent(new Event('change'));
+				}
+				
+				var line_4 = elements.search.closest('form').querySelector('#street_4');
+				if (line_4) {
+					line_4.value = '';
+					elements.line_4.dispatchEvent(new Event('change'));
+				}
+
+				cc_hide_fields(elements, 'show');
+			},
+			onError: function() {
+				if (typeof this.activeDom.postcode !== 'undefined') {
+					cc_hide_fields(this.activeDom, 'show');
+				} else {
+					c2a_config.autocomplete.advanced.hide_fields = false;
+				}
+			},
+			transliterate: c2a_config.autocomplete.advanced.transliterate,
+			excludeAreas: c2a_config.autocomplete.exclusions.areas,
+			excludePoBox: c2a_config.autocomplete.exclusions.po_box,
+			debug: c2a_config.autocomplete.advanced.debug,
+			cssPath: false,
+			tag: 'magento2'
+		};
+
+		if (typeof c2a_config.autocomplete.enabled_countries !== 'undefined') {
+			config.countryMatchWith = 'iso_2';
+			config.enabledCountries = c2a_config.autocomplete.enabled_countries;
+		}
+
+		if (c2a_config.autocomplete.advanced.lock_country_to_dropdown) {
+			config.countrySelector = false;
+			config.onSearchFocus = function(c2a, dom) {
+				var currentCountry = dom.country.options[dom.country.selectedIndex].value;
+				if (currentCountry !== '') {
+					var countryCode = getCountryCode(c2a, currentCountry, 'iso_2');
+					c2a.selectCountry(countryCode);
+				}
 			};
-
-			if (typeof c2a_config.autocomplete.enabled_countries !== 'undefined') {
-				config.countryMatchWith = 'iso_2';
-				config.enabledCountries = c2a_config.autocomplete.enabled_countries;
-			}
-
-			if (c2a_config.autocomplete.advanced.lock_country_to_dropdown) {
-				config.countrySelector = false;
-				config.onSearchFocus = function(c2a, dom) {
-					var currentCountry = dom.country.options[dom.country.selectedIndex].value;
-					if (currentCountry !== '') {
-						var countryCode = getCountryCode(c2a, currentCountry, 'iso_2');
-						c2a.selectCountry(countryCode);
-					}
-				};
-			}
-
-			window.cc_holder = new clickToAddress(config);
-			setInterval(cc_m2_c2a, 200);
 		}
 
-		if (c2a_config.autocomplete.enabled && c2a_config.main.key == null) {
-			console.warn('ClickToAddress: Incorrect token format supplied');
-		}
-
-		if (c2a_config.postcodelookup.enabled) {
-			setInterval(activate_cc_m2_uk, 200);
-		}
-
-		if (c2a_config.phonevalidation.enabled && c2a_config.main.key != null) {
-			if (window.cc_holder == null) {
-				window.cc_holder = new clickToAddress({
-					accessToken: c2a_config.main.key,
-				});
-			}
-			
-			setInterval(function() {
-				var phone_elements = jQuery('input[name="telephone"]');
-				phone_elements.each(function(index) {
-					var phone_element = phone_elements.eq(index);
-					if (phone_element.data('cc') != '1') {
-						phone_element.data('cc', '1');
-						var country = phone_element.closest('form').find('select[name="country_id"]');
-						window.cc_holder.addPhoneVerify({
-							phone: phone_element[0],
-							country: country[0]
-						});
-					}
-				});
-			}, 200);
-		}
-	});
-});
-
-// IE11 compatibility
-function triggerEvent(eventName, target) {
-	var event;
-	if (typeof (Event) === 'function') {
-		event = new Event(eventName);
-	} else {
-		event = document.createEvent('Event');
-		event.initEvent(eventName, true, true);
+		window.cc_holder = new clickToAddress(config);
+		setInterval(cc_m2_c2a, 200);
 	}
-	target.dispatchEvent(event);
+
+	if (c2a_config.autocomplete.enabled && c2a_config.main.key == null) {
+		console.warn('ClickToAddress: Incorrect token format supplied');
+	}
+
+	if (c2a_config.postcodelookup.enabled) {
+		setInterval(activate_cc_m2_uk, 200);
+	}
+
+	if (c2a_config.phonevalidation.enabled && c2a_config.main.key != null) {
+		if (window.cc_holder == null) {
+			window.cc_holder = new clickToAddress({
+				accessToken: c2a_config.main.key,
+			});
+		}
+		
+		setInterval(function() {
+			document.querySelectorAll('input[name="telephone"]').forEach(function(phone_element) {
+				if (phone_element.dataset.cc != '1') {
+					phone_element.dataset.cc = '1';
+					var country = phone_element.closest('form').querySelector('select[name="country_id"]');
+					window.cc_holder.addPhoneVerify({
+						phone: phone_element,
+						country: country
+					});
+				}
+			});
+		}, 200);
+	}
 }
+
+requirejs(['jquery'], function($) {
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', cc_init);
+	} else {
+		cc_init();
+	}
+});

--- a/view/frontend/web/form_integrations/cc_multishipping_register.js
+++ b/view/frontend/web/form_integrations/cc_multishipping_register.js
@@ -5,61 +5,100 @@ function cc_m2_c2a() {
 	 * (needed on sites that load page elements
 	 * via multiple ajax requests)
 	 */
-	if (jQuery('[name="postcode"]').length == 0) {
+	if (!document.querySelector('[name="postcode"]')) {
 		return;
 	}
 
-	var postcode_elem = jQuery('[name="postcode"]')[0];
+	var postcode_elem = document.querySelector('[name="postcode"]');
 
-	if (jQuery(postcode_elem).data('cc_attach') != '1') {
-		jQuery(postcode_elem).data('cc_attach', '1');
+	if (postcode_elem.dataset.cc_attach != '1') {
+		postcode_elem.dataset.cc_attach = '1';
 
-		var form = jQuery(postcode_elem).closest('form');
-		var custom_id = '';
-
-		if (c2a_config.autocomplete.advanced.search_elem_id !== null) {
-			custom_id = ' id="' + c2a_config.autocomplete.advanced.search_elem_id + '"';
-		}
+		var form = postcode_elem.closest('form');
 
 		// null fix for m2_1.1.16
 		if (c2a_config.autocomplete.texts.search_label == null) c2a_config.autocomplete.texts.search_label = '';
 
-		var tmp_html = '<div class="field"' + custom_id + '><label class="label" for="fetchify_search">' +
-			c2a_config.autocomplete.texts.search_label + '</label>' +
-			'<div class="control"><input class="cc_search_input" type="text" name="fetchify_search"/></div></div>';
+		var search_elem = document.createElement('input');
+		search_elem.classList.add('cc_search_input');
+		search_elem.name = 'fetchify_search';
+		search_elem.setAttribute('type', 'text');
 
-		if (c2a_config.autocomplete.advanced.hide_fields) {
-			var svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 305.67 179.25">' +
-				'<rect x="-22.85" y="66.4" width="226.32" height="47.53" rx="17.33" ry="17.33" transform="translate(89.52 -37.99) rotate(45)"/>' +
-				'<rect x="103.58" y="66.4" width="226.32" height="47.53" rx="17.33" ry="17.33" transform="translate(433.06 0.12) rotate(135)"/>' +
-				'</svg>';
-			tmp_html += '<div class="field cc_hide_fields_action"><label>' + c2a_config.autocomplete.texts.manual_entry_toggle + '</label>' + svg + '</div>';
-		}
+		var small_wrapper_elem = document.createElement('div');
+		small_wrapper_elem.classList.add('control');
+		small_wrapper_elem.appendChild(search_elem);
+
+		var label_elem = document.createElement('label');
+		label_elem.classList.add('label');
+		label_elem.setAttribute('for', 'fetchify_search');
+		label_elem.textContent = c2a_config.autocomplete.texts.search_label;
+
+		var big_wrapper_elem = document.createElement('div');
+		if (c2a_config.autocomplete.advanced.search_elem_id !== null) { big_wrapper_elem.id = c2a_config.autocomplete.advanced.search_elem_id; } // custom id
+		big_wrapper_elem.classList.add('field');
+		big_wrapper_elem.appendChild(label_elem);
+		big_wrapper_elem.appendChild(small_wrapper_elem);
 
 		if (!c2a_config.autocomplete.advanced.use_first_line || c2a_config.autocomplete.advanced.hide_fields) {
-			form.find('#street_1').closest('.field').before(tmp_html);
+			form.querySelector('#street_1').closest('.field').before(big_wrapper_elem);
 		} else {
-			form.find('#street_1').addClass('cc_search_input');
+			form.querySelector('#street_1').classList.add('cc_search_input');
+		}
+
+		if (c2a_config.autocomplete.advanced.hide_fields) {
+			var rect1_elem = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+			rect1_elem.setAttribute('x', '-22.85');
+			rect1_elem.setAttribute('y', '66.4');
+			rect1_elem.setAttribute('width', '226.32');
+			rect1_elem.setAttribute('height', '47.53');
+			rect1_elem.setAttribute('rx', '17.33');
+			rect1_elem.setAttribute('ry', '17.33');
+			rect1_elem.setAttribute('transform', 'translate(89.52 -37.99) rotate(45)');
+
+			var rect2_elem = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+			rect2_elem.setAttribute('x', '103.58');
+			rect2_elem.setAttribute('y', '66.4');
+			rect2_elem.setAttribute('width', '226.32');
+			rect2_elem.setAttribute('height', '47.53');
+			rect2_elem.setAttribute('rx', '17.33');
+			rect2_elem.setAttribute('ry', '17.33');
+			rect2_elem.setAttribute('transform', 'translate(433.06 0.12) rotate(135)');
+
+			var svg_elem = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+			svg_elem.setAttribute('viewBox', '0 0 305.67 179.25');
+			svg_elem.appendChild(rect1_elem);
+			svg_elem.appendChild(rect2_elem);
+
+			var manual_entry_label_elem = document.createElement('label');
+			manual_entry_label_elem.innerText = c2a_config.autocomplete.texts.manual_entry_toggle;
+			manual_entry_label_elem.style.cursor = 'pointer';
+
+			var manual_entry_wrapper_elem = document.createElement('div');
+			manual_entry_wrapper_elem.classList.add('field', 'cc_hide_fields_action');
+			manual_entry_wrapper_elem.appendChild(manual_entry_label_elem);
+			manual_entry_wrapper_elem.appendChild(svg_elem);
+
+			form.querySelector('.cc_search_input').closest('div.field').after(manual_entry_wrapper_elem);
 		}
 
 		if (c2a_config.autocomplete.advanced.lock_country_to_dropdown) {
-			form.find('.cc_search_input').closest('div.field').before(form.find('[name="country_id"]').closest('div.field'));
+			form.querySelector('.cc_search_input').closest('div.field').before(form.querySelector('[name="country_id"]').closest('div.field'));
 		}
 
 		var config = {
 			accessToken: c2a_config.main.key,
 			dom: {
-				search:		form.find('.cc_search_input')[0],
-				company:	form.find('[name="company"]')[0],
-				line_1:		form.find('#street_1')[0],
-				line_2:		form.find('#street_2')[0],
-				postcode:	form.find('[name="postcode"]')[0],
-				town:		form.find('[name="city"]')[0],
+				search:		form.querySelector('.cc_search_input'),
+				company:	form.querySelector('[name="company"]'),
+				line_1:		form.querySelector('#street_1'),
+				line_2:		form.querySelector('#street_2'),
+				postcode:	form.querySelector('[name="postcode"]'),
+				town:		form.querySelector('[name="city"]'),
 				county: {
-					input: form.find('[name="region"]'),
-					list: form.find('[name="region_id"]')
+					input: form.querySelector('[name="region"]'),
+					list: form.querySelector('[name="region_id"]')
 				},
-				country:	form.find('[name="country_id"]')[0]
+				country:	form.querySelector('[name="country_id"]')
 			},
 			onSetCounty: function(c2a, elements, county) {
 				return;
@@ -79,13 +118,13 @@ function cc_m2_c2a() {
 					case 'JE':
 					case 'GG':
 					case 'IM':
-						jQuery(elements.country).val(postcode);
+						elements.country.value = postcode;
 						break;
 					default:
-						jQuery(elements.country).val(address.country.iso_3166_1_alpha_2);
+						elements.country.value = address.country.iso_3166_1_alpha_2;
 				}
 
-				if (typeof elements.country != 'undefined') { triggerEvent('change', elements.country); }
+				if (typeof elements.country != 'undefined') { elements.country.dispatchEvent(new Event('change')); }
 
 				var county;
 				if (c2a.activeCountry === 'gbr' && !c2a_config.autocomplete.advanced.fill_uk_counties) {
@@ -98,32 +137,32 @@ function cc_m2_c2a() {
 					};
 				}
 
-				if (elements.county.list.length == 1) {
-					c2a.setCounty(elements.county.list[0], county);
+				if (elements.county.list) {
+					c2a.setCounty(elements.county.list, county);
 				}
 
-				if (elements.county.input.length == 1) {
-					c2a.setCounty(elements.county.input[0], county);
+				if (elements.county.input) {
+					c2a.setCounty(elements.county.input, county);
 				}
 
-				if (typeof elements.county.input[0] != 'undefined') triggerEvent('change', elements.county.input[0]);
-				if (typeof elements.county.list[0] != 'undefined') triggerEvent('change', elements.county.list[0]);
-				if (typeof elements.company != 'undefined') triggerEvent('change', elements.company);
-				if (typeof elements.line_1 != 'undefined') triggerEvent('change', elements.line_1);
-				if (typeof elements.line_2 != 'undefined') triggerEvent('change', elements.line_2);
-				if (typeof elements.postcode != 'undefined') triggerEvent('change', elements.postcode);
-				if (typeof elements.town != 'undefined') triggerEvent('change', elements.town);
+				if (elements.county.input) elements.county.input.dispatchEvent(new Event('change'));
+				if (elements.county.list) elements.county.list.dispatchEvent(new Event('change'));
+				if (elements.company) elements.company.dispatchEvent(new Event('change'));
+				if (elements.line_1) elements.line_1.dispatchEvent(new Event('change'));
+				if (elements.line_2) elements.line_2.dispatchEvent(new Event('change'));
+				if (elements.postcode) elements.postcode.dispatchEvent(new Event('change'));
+				if (elements.town) elements.town.dispatchEvent(new Event('change'));
 
-				var line_3 = jQuery(elements.search).closest('form').find('#street_3');
-				if (line_3.length !== 0) {
-					line_3.val('');
-					triggerEvent('change', line_3[0]);
+				var line_3 = elements.search.closest('form').querySelector('#street_3');
+				if (line_3) {
+					line_3.value = '';
+					line_3.dispatchEvent(new Event('change'));
 				}
 				
-				var line_4 = jQuery(elements.search).closest('form').find('#street_4');
-				if (line_4.length !== 0) {
-					line_4.val('');
-					triggerEvent('change', line_4[0]);
+				var line_4 = elements.search.closest('form').querySelector('#street_4');
+				if (line_4) {
+					line_4.value = '';
+					line_4.dispatchEvent(new Event('change'));
 				}
 
 				cc_hide_fields(elements, 'show');
@@ -154,26 +193,27 @@ function cc_m2_c2a() {
 
 		window.cc_holder = new clickToAddress(config);
 
-		// cc_hide_fields expect jquery elements
-		var jquery_dom = {
-			search:		form.find('.cc_search_input'),
-			company:	form.find('[name="company"]'),
-			line_1:		form.find('#street_1'),
-			line_2:		form.find('#street_2'),
-			postcode:	form.find('[name="postcode"]'),
-			town:		form.find('[name="city"]'),
+		var dom = {
+			search:		form.querySelector('.cc_search_input'),
+			company:	form.querySelector('[name="company"]'),
+			line_1:		form.querySelector('#street_1'),
+			line_2:		form.querySelector('#street_2'),
+			postcode:	form.querySelector('[name="postcode"]'),
+			town:		form.querySelector('[name="city"]'),
 			county: {
-				input: form.find('[name="region"]'),
-				list: form.find('[name="region_id"]')
+				input: form.querySelector('[name="region"]'),
+				list: form.querySelector('[name="region_id"]')
 			},
-			country:	form.find('[name="country_id"]')
+			country:	form.querySelector('[name="country_id"]')
 		};
 
-		form.find('.cc_hide_fields_action').on('click', function() {
-			cc_hide_fields(jquery_dom, 'manual-show');
-		});
+		if (c2a_config.autocomplete.advanced.hide_fields) {
+			form.querySelector('.cc_hide_fields_action').addEventListener('click', () => {
+				cc_hide_fields(dom, 'manual-show');
+			});
+		}
 
-		cc_hide_fields(jquery_dom, 'init');
+		cc_hide_fields(dom, 'init');
 	}
 }
 
@@ -181,8 +221,8 @@ function cc_m2_c2a() {
 var cc_activate_flags = [];
 function activate_cc_m2_uk() {
 	if (c2a_config.postcodelookup.enabled) {
-		var cfg = {
-			id: '',
+		var active_cfg = {
+			id: 'm2_address',
 			core: {
 				key: c2a_config.main.key,
 				preformat: true,
@@ -193,7 +233,18 @@ function activate_cc_m2_uk() {
 					town: true
 				}
 			},
-			dom: {},
+			dom: {
+				company:	document.querySelector('[name="company"]'),
+				address_1:	document.querySelector('#street_1'),
+				address_2:	document.querySelector('#street_2'),
+				address_3:	document.querySelector('#street_3'),
+				address_4:	document.querySelector('#street_4'),
+				postcode:	document.querySelector('[name="postcode"]'),
+				town:		document.querySelector('[name="city"]'),
+				county:		document.querySelector('[name="region"]'),
+				county_list:document.querySelector('[name="region_id"]'),
+				country:	document.querySelector('[name="country_id"]')
+			},
 			sort_fields: {
 				active: true,
 				parent: '.field:not(.additional)'
@@ -204,78 +255,116 @@ function activate_cc_m2_uk() {
 			county_data: c2a_config.postcodelookup.advanced.county_data,
 			ui: {
 				onResultSelected: function(dataset, id, fields) {
-					if (cfg.county_data == 'former_postal') {
-						fields.county[0].value = dataset.postal_county;
-					} else if (cfg.county_data == 'traditional') {
-						fields.county[0].value = dataset.traditional_county;
+					if (active_cfg.county_data == 'former_postal') {
+						fields.county.value = dataset.postal_county;
+					} else if (active_cfg.county_data == 'traditional') {
+						fields.county.value = dataset.traditional_county;
 					} else {
-						fields.county[0].value = '';
+						fields.county.value = '';
 					}
-					fields.county.trigger('change');
-					fields.postcode.closest('form').find('.cp_manual_entry').hide(200);
-					fields.address_4.val('').change();
+					if (fields.county) fields.county.dispatchEvent(new Event('change'));
+					fields.postcode.closest('form').querySelector('.cp_manual_entry').style.display = 'none';
+					if (fields.address_4) {
+						fields.address_4.value = '';
+						fields.address_4.dispatchEvent(new Event('change'));
+					}
 				}
 			}
 		};
 
-		var address_dom = {
-			company:	jQuery('[name="company"]'),
-			address_1:	jQuery('#street_1'),
-			address_2:	jQuery('#street_2'),
-			address_3:	jQuery('#street_3'),
-			address_4:	jQuery('#street_4'),
-			postcode:	jQuery('[name="postcode"]'),
-			town:		jQuery('[name="city"]'),
-			county:		jQuery('[name="region"]'),
-			county_list:jQuery('[name="region_id"]'),
-			country:	jQuery('[name="country_id"]')
-		};
-
-		cfg.dom = address_dom;
-		cfg.id = 'm2_address';
-
-		if (cc_activate_flags.indexOf(cfg.id) == -1 && cfg.dom.postcode.length == 1) {
-			cc_activate_flags.push(cfg.id);
+		if (cc_activate_flags.indexOf(active_cfg.id) == -1 && active_cfg.dom.postcode) {
+			cc_activate_flags.push(active_cfg.id);
 
 			// modify the Layout
-			var postcode_elem = cfg.dom.postcode;
-			postcode_elem.wrap('<div class="search-bar"></div>');
+			var postcode_elem = active_cfg.dom.postcode;
 
-			// button has to go before input elem otherwise layout messed up when m2 validaton alert is displayed
-			postcode_elem.before('<button type="button" class="action primary">' +
-				'<span>' + cfg.txt.search_buttontext + '</span></button>');
+			var postcode_wrapper_elem = document.createElement('div');
+			postcode_wrapper_elem.classList.add('search-bar');
+			postcode_elem.replaceWith(postcode_wrapper_elem);
+			postcode_wrapper_elem.appendChild(postcode_elem);
+
+			var button_text_elem = document.createElement('span');
+			button_text_elem.textContent = active_cfg.txt.search_buttontext;
+
+			var button_elem = document.createElement('button');
+			button_elem.setAttribute('type', 'button'); // Required to prevent form from submitting
+			button_elem.classList.add('action', 'primary');
+			button_elem.appendChild(button_text_elem);
+			postcode_elem.before(button_elem);
 
 			// STANDARD
-			postcode_elem.closest('.search-bar').after('<div class="search-list" style="display: none;"><select></select></div>' +
-				'<div class="mage-error" generated><div class="search-subtext"></div></div>');
+			var error_elem = document.createElement('div');
+			error_elem.classList.add('search-subtext');
 
-			/* m2 expects the alert elem to be directly after postcode 
-			input, so let's move it back there to prevent m2 using our 
-			button for displaying invalid postcode error text */
-			postcode_elem.after(postcode_elem.closest('.control').find('[role="alert"]'));
+			var error_wrapper_elem = document.createElement('div');
+			error_wrapper_elem.classList.add('mage-error');
+			error_wrapper_elem.setAttribute('generated', '');
+			error_wrapper_elem.appendChild(error_elem);
+			postcode_wrapper_elem.after(error_wrapper_elem);
 
-			var new_container = postcode_elem.closest(cfg.sort_fields.parent);
-			new_container.addClass('search-container').attr('id', cfg.id).addClass('type_3');
+			var results_elem = document.createElement('select');
+
+			var results_wrapper_elem = document.createElement('div');
+			results_wrapper_elem.classList.add('search-list');
+			results_wrapper_elem.style.display = 'none';
+			results_wrapper_elem.appendChild(results_elem);
+			postcode_wrapper_elem.after(results_wrapper_elem);
+
+			var new_container = postcode_elem.closest(active_cfg.sort_fields.parent);
+			new_container.id = active_cfg.id;
+			new_container.classList.add('search-container', 'type_3');
 			
 			// add/show manual entry text
 			var form = postcode_elem.closest('form');
-			if (cfg.hide_fields) {
-				if (jQuery('#' + cfg.id + '_cp_manual_entry').length === 0 && postcode_elem.val() === '') {
-					var svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 305.67 179.25">' +
-						'<rect x="-22.85" y="66.4" width="226.32" height="47.53" rx="17.33" ry="17.33" transform="translate(89.52 -37.99) rotate(45)"/>' +
-						'<rect x="103.58" y="66.4" width="226.32" height="47.53" rx="17.33" ry="17.33" transform="translate(433.06 0.12) rotate(135)"/>' +
-						'</svg>';
-					tmp_manual_html = '<div class="field cp_manual_entry" id="' + cfg.id + '_cp_manual_entry" style="margin-top: 15px; margin-bottom: 15px;"><label>' + cfg.txt.manual_entry + '</label>' + svg + '</div>';
-					jQuery(postcode_elem).after(tmp_manual_html);
+			if (active_cfg.hide_fields) {
+				if (!document.getElementById(active_cfg.id + '_cp_manual_entry') && postcode_elem.value === '') {
+					var rect1_elem = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+					rect1_elem.setAttribute('x', '-22.85');
+					rect1_elem.setAttribute('y', '66.4');
+					rect1_elem.setAttribute('width', '226.32');
+					rect1_elem.setAttribute('height', '47.53');
+					rect1_elem.setAttribute('rx', '17.33');
+					rect1_elem.setAttribute('ry', '17.33');
+					rect1_elem.setAttribute('transform', 'translate(89.52 -37.99) rotate(45)');
 
-					jQuery('#' + cfg.id + '_cp_manual_entry').on('click', function() {
-						jQuery(form).find('.crafty_address_field').removeClass('crafty_address_field_hidden');
-						jQuery('#' + cfg.id + '_cp_manual_entry').hide(200);
+					var rect2_elem = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+					rect2_elem.setAttribute('x', '103.58');
+					rect2_elem.setAttribute('y', '66.4');
+					rect2_elem.setAttribute('width', '226.32');
+					rect2_elem.setAttribute('height', '47.53');
+					rect2_elem.setAttribute('rx', '17.33');
+					rect2_elem.setAttribute('ry', '17.33');
+					rect2_elem.setAttribute('transform', 'translate(433.06 0.12) rotate(135)');
+
+					var svg_elem = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+					svg_elem.setAttribute('viewBox', '0 0 305.67 179.25');
+					svg_elem.setAttribute('style', 'display: inline-block; width: 1em;');
+					svg_elem.appendChild(rect1_elem);
+					svg_elem.appendChild(rect2_elem);
+
+					var manual_entry_label_elem = document.createElement('label');
+					manual_entry_label_elem.textContent = active_cfg.txt.manual_entry;
+					manual_entry_label_elem.style.cursor = 'pointer';
+
+					var manual_entry_wrapper_elem = document.createElement('div');
+					manual_entry_wrapper_elem.id = active_cfg.id + '_cp_manual_entry';
+					manual_entry_wrapper_elem.classList.add('field', 'cp_manual_entry');
+					manual_entry_wrapper_elem.style.margin = '15px 0 15px 0';
+					manual_entry_wrapper_elem.appendChild(manual_entry_label_elem);
+					manual_entry_wrapper_elem.appendChild(svg_elem);
+
+					postcode_elem.after(manual_entry_wrapper_elem);
+
+					document.getElementById(active_cfg.id + '_cp_manual_entry').addEventListener('click', () => {
+						form.querySelectorAll('.crafty_address_field').forEach((element) => {
+							element.classList.remove('crafty_address_field_hidden');
+						});
+						document.getElementById(active_cfg.id + '_cp_manual_entry').style.display = 'none';
 					});
 				}
 			}
 
-			var cc_multishipping_register = new cc_ui_handler(cfg);
+			var cc_multishipping_register = new cc_ui_handler(active_cfg);
 			cc_multishipping_register.activate();
 		}
 	}
@@ -293,13 +382,13 @@ function cc_m2_phone() {
 	}
 
 	var add_phone = setInterval(function() {
-		var phone_element = jQuery('input[name="telephone"]');
-		if (phone_element.length == 1 && phone_element.data('cc') != '1') {
-			phone_element.data('cc', '1');
-			var country = phone_element.closest('form').find('select[name="country_id"]');
+		var phone_element = document.querySelector('input[name="telephone"]');
+		if (phone_element && phone_element.dataset.cc != '1') {
+			phone_element.dataset.cc = '1';
+			var country = phone_element.closest('form').querySelector('select[name="country_id"]');
 			window.cc_holder.addPhoneVerify({
-				phone: phone_element[0],
-				country: country[0]
+				phone: phone_element,
+				country: country
 			});
 			clearInterval(add_phone);
 		}
@@ -318,11 +407,11 @@ function cc_m2_email() {
 	}
 
 	var add_email = setInterval(function() {
-		var email_element = jQuery('input#email_address');
-		if (email_element.data('cc') != '1') {
-			email_element.data('cc', '1');
+		var email_element = document.querySelector('input#email_address');
+		if (email_element.dataset.cc != '1') {
+			email_element.dataset.cc = '1';
 			window.cc_holder.addEmailVerify({
-				email: email_element[0]
+				email: email_element
 			});
 			clearInterval(add_email);
 		}
@@ -343,7 +432,7 @@ function cc_hide_fields(dom, action) {
 			var elementsToHide = ['line_1', 'line_2', 'line_3', 'line_4', 'town', 'postcode', 'county'];
 			var formEmpty = true;
 			for (var i = 0; i < elementsToHide.length - 1; i++) { // -1 is to skip County
-				if (jQuery(dom[elementsToHide[i]]).length && jQuery(dom[elementsToHide[i]]).val() !== '') {
+				if (dom[elementsToHide[i]] && dom[elementsToHide[i]].value !== '') {
 					formEmpty = false;
 				}
 			}
@@ -353,24 +442,24 @@ function cc_hide_fields(dom, action) {
 			}
 
 			for (var i = 0; i < elementsToHide.length; i++) {
-				if (jQuery(dom[elementsToHide[i]]).length) {
+				if (dom[elementsToHide[i]]) {
 					switch (elementsToHide[i]) {
 						case 'county':
-							jQuery(dom[elementsToHide[i]].input).closest('.field').addClass('cc_hide');
-							jQuery(dom[elementsToHide[i]].list).closest('.field').addClass('cc_hide');
+							dom[elementsToHide[i]].input.closest('.field').classList.add('cc_hide');
+							dom[elementsToHide[i]].list.closest('.field').classList.add('cc_hide');
 							break;
 						case 'line_1':
-							jQuery(dom[elementsToHide[i]]).closest('.field').addClass('cc_hide');
+							dom[elementsToHide[i]].closest('.field').classList.add('cc_hide');
 							break;
 						default:
-							jQuery(dom[elementsToHide[i]]).closest('.field').addClass('cc_hide');
+							dom[elementsToHide[i]].closest('.field').classList.add('cc_hide');
 					}
 				}
 			}
 
 			// store the checking loop in the DOM object
-			var form = jQuery(dom.country).closest('form');
-			form.data('cc_hidden', 0);
+			var form = dom.country.closest('form');
+			form.dataset.cc_hidden = '0';
 
 			if (formEmpty) {
 				cc_hide_fields(dom, 'hide');
@@ -381,31 +470,31 @@ function cc_hide_fields(dom, action) {
 			setInterval(function() { cc_reveal_fields_on_error(dom); }, 250);
 			break;
 		case 'hide':
-			var form = jQuery(dom.country).closest('form');
-			form.find('.cc_hide').each(function(index, item) {
-				jQuery(item).addClass('cc_hidden');
+			var form = dom.country.closest('form');
+			form.querySelectorAll('.cc_hide').forEach(function(item) {
+				item.classList.add('cc_hidden');
 			});
-			form.find('.cc_hide_fields_action').removeClass('cc_slider_on');
-			form.data('cc_hidden', 1);
+			form.querySelector('.cc_hide_fields_action').classList.remove('cc_slider_on');
+			form.dataset.cc_hidden = '1';
 			break;
 		case 'manual-show':
 		case 'show':
-			jQuery(dom.country).trigger('change');
+			dom.country.dispatchEvent(new Event('change'));
 
-			var form = jQuery(dom.country).closest('form');
-			form.find('.cc_hide').each(function(index, item) {
-				jQuery(item).removeClass('cc_hidden');
+			var form = dom.country.closest('form');
+			form.querySelectorAll('.cc_hide').forEach(function(item) {
+				item.classList.remove('cc_hidden');
 			});
-			form.find('.cc_hide_fields_action').hide(200);
-			form.data('cc_hidden', 0);
+			form.querySelector('.cc_hide_fields_action').style.display = 'none';
+			form.dataset.cc_hidden = '0';
 
 			if (action == 'manual-show') {
-				jQuery(dom.country).trigger('change');
+				dom.country.dispatchEvent(new Event('change'));
 			}
 			break;
 		case 'toggle':
-			var form = jQuery(dom.country).closest('form');
-			if (form.data('cc_hidden') == 1) {
+			var form = dom.country.closest('form');
+			if (form.dataset.cc_hidden == '1') {
 				cc_hide_fields(dom, 'show');
 			} else {
 				cc_hide_fields(dom, 'hide');
@@ -415,55 +504,50 @@ function cc_hide_fields(dom, action) {
 }
 
 function cc_reveal_fields_on_error(dom) {
-	var form = jQuery(dom.country).closest('form');
+	var form = dom.country.closest('form');
 	var errors_present = false;
 	
-	form.find('.cc_hide').each(function(index, item) {
-		if (jQuery(item).hasClass('_error')) {
+	form.querySelectorAll('.cc_hide').forEach(function(item) {
+		if (item.classList.contains('_error')) {
 			errors_present = true;
 		}
 	});
 
 	if (errors_present) {
 		cc_hide_fields(dom, 'show');
-		form.find('.cc_hide_fields_action').hide(); // prevent the user from hiding the fields again
+		form.querySelector('.cc_hide_fields_action').style.display = 'none'; // prevent the user from hiding the fields again
+	}
+}
+
+function cc_init() {
+	if (!c2a_config.main.enable_extension) { return; }
+
+	if (c2a_config.main.enable_extension && c2a_config.main.key == null) {
+		console.warn('Fetchify: No access token configured.');
+		return;
+	}
+
+	if (c2a_config.autocomplete.enabled) {
+		setInterval(cc_m2_c2a, 200);
+	}
+
+	if (c2a_config.postcodelookup.enabled) {
+		setInterval(activate_cc_m2_uk, 200);
+	}
+
+	if (c2a_config.phonevalidation.enabled) {
+		setInterval(cc_m2_phone, 200);
+	}
+
+	if (c2a_config.emailvalidation.enabled && c2a_config.main.key != null) {
+		setInterval(cc_m2_email, 200);
 	}
 }
 
 requirejs(['jquery'], function($) {
-	jQuery(document).ready(function() {
-		if (!c2a_config.main.enable_extension) { return; }
-
-		if (c2a_config.main.enable_extension && c2a_config.main.key == null) {
-			console.warn('Fetchify: No access token configured.');
-			return;
-		}
-
-		if (c2a_config.autocomplete.enabled) {
-			setInterval(cc_m2_c2a, 200);
-		}
-
-		if (c2a_config.postcodelookup.enabled) {
-			setInterval(activate_cc_m2_uk, 200);
-		}
-
-		if (c2a_config.phonevalidation.enabled) {
-			setInterval(cc_m2_phone, 200);
-		}
-
-		if (c2a_config.emailvalidation.enabled && c2a_config.main.key != null) {
-			setInterval(cc_m2_email, 200);
-		}
-	});
-});
-
-function triggerEvent(eventName, target) {
-	var event;
-	if (typeof (Event) === 'function') {
-		event = new Event(eventName);
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', cc_init);
 	} else {
-		event = document.createEvent('Event');
-		event.initEvent(eventName, true, true);
+		cc_init();
 	}
-	target.dispatchEvent(event);
-}
+});


### PR DESCRIPTION
* Added email validation to the New Order admin page
* Fixed a bug where address lines 3 and 4 were not cleared when selecting an Address Auto-Complete result on the New Order admin page
* Fixed a bug where the shipping address was not updated after selecting an Address Auto-Complete result for the billing address on the New Order admin page when the "Same as Billing Address" option is enabled
* Fixed a bug where enabling the "Use first address line for search" option would break Address Auto-Complete for the Hyvä Checkout